### PR TITLE
Load auth in receive and pass through pipeline

### DIFF
--- a/channels/facebook/post/index.js
+++ b/channels/facebook/post/index.js
@@ -18,13 +18,8 @@
 
 const assert = require('assert');
 const request = require('request');
-const Cloudant = require('cloudant');
 const omit = require('object.omit');
-const openwhisk = require('openwhisk');
 
-const CLOUDANT_URL = 'cloudant_url';
-const CLOUDANT_AUTH_DBNAME = 'cloudant_auth_dbname';
-const CLOUDANT_AUTH_KEY = 'cloudant_auth_key';
 /**
  *  Receives a Facebook POST JSON object and sends the object to the Facebook API.
  *
@@ -40,24 +35,21 @@ function main(params) {
       reject(e.message);
     }
 
+    const auth = params.raw_input_data.auth;
+
+    assert(
+      auth.facebook && auth.facebook.page_access_token,
+      'auth.facebook.page_access_token not found.'
+    );
+
     const facebookParams = extractFacebookParams(params);
     const postUrl = params.url || 'https://graph.facebook.com/v2.6/me/messages';
 
-    getCloudantCreds()
-      .then(cloudantCreds => {
-        return loadAuth(cloudantCreds);
-      })
-      .then(auth => {
-        assert(
-          auth.facebook && auth.facebook.page_access_token,
-          'auth.facebook.page_access_token not found.'
-        );
-        return postFacebook(
-          facebookParams,
-          postUrl,
-          auth.facebook.page_access_token
-        );
-      })
+    return postFacebook(
+      facebookParams,
+      postUrl,
+      auth.facebook.page_access_token
+    )
       .then(resolve)
       .catch(reject);
   });
@@ -109,208 +101,6 @@ function postFacebook(params, postUrl, accessToken) {
 }
 
 /**
- *  Gets the annotations for the package specified.
- *
- *  @packageName  {string} Name of the package whose annotations are needed
- *
- *  @return - package annotations array
- *  eg: [
- *     {
- *       key: 'cloudant_url',
- *       value: 'https://some-cloudant-url'
- *     },
- *     {
- *       key: 'cloudant_auth_dbname',
- *       value: 'authdb'
- *     },
- *     {
- *       key: 'cloudant_auth_key',
- *       value: '123456'
- *     }
- *   ]
- */
-function getPackageAnnotations(packageName) {
-  return new Promise((resolve, reject) => {
-    openwhisk().packages
-      .get(packageName)
-      .then(pkg => {
-        resolve(pkg.annotations);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Gets the package name from the action name that lives in it.
- *
- *  @actionName  {string} Full name of the action from which
- *               package name is to be extracted.
- *
- *  @return - package name
- *  eg: full action name = '/org_space/pkg/action' then,
- *      package name = 'pkg'
- */
-function extractCurrentPackageName(actionName) {
-  return actionName.split('/')[2];
-}
-
-/**
- *  Gets the cloudant credentials (saved as package annotations)
- *  from the current action's full name, derived from
- *  the env var "__OW_ACTION_NAME".
- *
- *  @return - cloudant credentials to use for db read/write operations.
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function getCloudantCreds() {
-  return new Promise((resolve, reject) => {
-    // Get annotations of the current package.
-    const packageName = extractCurrentPackageName(process.env.__OW_ACTION_NAME);
-    getPackageAnnotations(packageName)
-      .then(annotations => {
-        // Construct a Cloudant creds json obj
-        const cloudantCreds = {};
-        annotations.forEach(a => {
-          cloudantCreds[a.key] = a.value;
-        });
-        checkCloudantCredentials(cloudantCreds);
-        resolve(cloudantCreds);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Verifies that cloudant creds contain all the keys
- *  necessary for db operations.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function checkCloudantCredentials(cloudantCreds) {
-  // Verify that all required Cloudant credentials are present.
-  assert(
-    cloudantCreds[CLOUDANT_URL],
-    'cloudant_url absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_DBNAME],
-    'cloudant_auth_dbname absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_KEY],
-    'cloudant_auth_key absent in cloudant credentials.'
-  );
-}
-
-/**
- *  Loads the auth info from the Cloudant auth db
- *  using supplied Cloudant credentials.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *
- *  @return auth information loaded from Cloudant
- *  eg:
- *   {
- *     "conversation": {
- *       "password": "xxxxxx",
- *       "username": "xxxxxx",
- *       "workspace_id": "xxxxxx"
- *     },
- *     "facebook": {
- *       "app_secret": "xxxxxx",
- *       "page_access_token": "xxxxxx",
- *       "verification_token": "xxxxxx"
- *     },
- *     "slack": {
- *       "client_id": "xxxxxx",
- *       "client_secret": "xxxxxx",
- *       "verification_token": "xxxxxx",
- *       "access_token": "xxxxxx",
- *       "bot_access_token": "xxxxxx"
- *     }
- *   }
- */
-function loadAuth(cloudantCreds) {
-  return new Promise((resolve, reject) => {
-    const cloudantUrl = cloudantCreds[CLOUDANT_URL];
-    const cloudantAuthDbName = cloudantCreds[CLOUDANT_AUTH_DBNAME];
-    const cloudantAuthKey = cloudantCreds[CLOUDANT_AUTH_KEY];
-    createCloudantObj(cloudantUrl)
-      .then(cloudantObj => {
-        return retrieveDoc(
-          cloudantObj.use(cloudantAuthDbName),
-          cloudantAuthKey
-        );
-      })
-      .then(auth => {
-        resolve(auth);
-      })
-      .catch(err => {
-        reject(err);
-      });
-  });
-}
-
-/**
- * Creates the Cloudant object using the Cloudant url specified
- *
- *  @cloudantUrl - {string} Cloudant url linked to the
- *                 user's Cloudant instance.
- *
- * @return Cloudant object or, rejects with the exception from Cloudant
- */
-function createCloudantObj(cloudantUrl) {
-  return new Promise((resolve, reject) => {
-    try {
-      const cloudant = Cloudant({
-        url: cloudantUrl,
-        plugin: 'retry',
-        retryAttempts: 5,
-        retryTimeout: 1000
-      });
-      resolve(cloudant);
-    } catch (err) {
-      reject(err);
-    }
-  });
-}
-
-/**
- * Retrieves the doc from the Cloudant db using the key provided.
- *
- *  @db - {Object} Cloudant db object
- *  @key - {string} key to use for retrieving doc
- *
- *  @return doc or, rejects with an exception from Cloudant
- */
-function retrieveDoc(db, key) {
-  return new Promise((resolve, reject) => {
-    db.get(
-      key,
-      {
-        // We need to add revision ids to prevent Cloudant update conflicts during writes
-        revs_info: true
-      },
-      (error, response) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(response);
-      }
-    );
-  });
-}
-
-/**
  *  Extracts and converts the input parameters to JSON that Facebook understands.
  *
  *  @params The parameters passed into the action
@@ -342,16 +132,19 @@ function validateParameters(params) {
   assert(params.recipient && params.recipient.id, 'Recepient id not provided.');
   // Required: Message to send
   assert(params.message, 'Message object not provided.');
+
+  // Required: raw_input_data and Facebook Auth
+  assert(
+    params.raw_input_data &&
+      params.raw_input_data.auth &&
+      params.raw_input_data.auth.facebook,
+    'Facebook auth not provided.'
+  );
 }
 
 module.exports = {
   main,
   name: 'facebook/post',
   postFacebook,
-  validateParameters,
-  loadAuth,
-  createCloudantObj,
-  getCloudantCreds,
-  checkCloudantCredentials,
-  retrieveDoc
+  validateParameters
 };

--- a/channels/facebook/receive/index.js
+++ b/channels/facebook/receive/index.js
@@ -109,7 +109,8 @@ function main(params) {
           // Get the appropriate payload for action invocation i.e. depending on whether it's a
           // a batched message or not we construct the appropriate payload
           const [actionParams, actionName] = getPayloadForActionInvocation(
-            params
+            params,
+            auth
           );
           // Invoke appropriate Cloud Functions action
           return invokeAction(actionParams, actionName);
@@ -135,20 +136,24 @@ function main(params) {
  * @param {JSON} params Params coming into this action
  * @return actionParams, actionName
  */
-function getPayloadForActionInvocation(params) {
+function getPayloadForActionInvocation(params, auth) {
   let actionName;
   let actionParams;
   // Check if it's a batched message
   if (isBatchedMessage(params)) {
     // Set action params and action name for batched messages invocation
     actionParams = params;
+    // Attach auth to params
+    actionParams.auth = auth;
     actionName = params.batched_messages;
   } else {
     // Set action params and action name for subpipeline invocation
     actionParams = {
       facebook: params.entry[0].messaging[0],
-      provider: 'facebook'
+      provider: 'facebook',
+      auth
     };
+
     actionName = params.sub_pipeline;
   }
   // Return action params and action name for the action that is to be invoked

--- a/channels/slack/post/index.js
+++ b/channels/slack/post/index.js
@@ -18,18 +18,12 @@
 
 const assert = require('assert');
 const request = require('request');
-const Cloudant = require('cloudant');
-const openwhisk = require('openwhisk');
 
 const mustUrlEncodeUrls = [
   'https://slack.com/api/chat.postMessage',
   'https://slack.com/api/chat.update',
   'https://slack.com/api/chat.postEphemeral'
 ];
-
-const CLOUDANT_URL = 'cloudant_url';
-const CLOUDANT_AUTH_DBNAME = 'cloudant_auth_dbname';
-const CLOUDANT_AUTH_KEY = 'cloudant_auth_key';
 
 /**
  * Receives a Slack POST JSON object and sends the object to the Slack API.
@@ -43,221 +37,14 @@ function main(params) {
     validateParameters(params);
     const postUrl = params.url || 'https://slack.com/api/chat.postMessage';
 
+    const auth = params.raw_input_data.auth;
+
     const postParams = extractSlackParameters(params);
 
-    getCloudantCreds()
-      .then(cloudantCreds => {
-        return loadAuth(cloudantCreds);
-      })
-      .then(auth => {
-        return postSlack(useAuth(postParams, auth), postUrl);
-      })
+    return postSlack(useAuth(postParams, auth), postUrl)
       .then(resolve)
       .catch(reject);
   });
-}
-
-/**
- *  Gets the cloudant credentials (saved as package annotations)
- *  from the current action's full name, derived from
- *  the env var "__OW_ACTION_NAME".
- *
- *  @return - cloudant credentials to use for db read/write operations.
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function getCloudantCreds() {
-  return new Promise((resolve, reject) => {
-    // Get annotations of the current package.
-    const packageName = extractCurrentPackageName(process.env.__OW_ACTION_NAME);
-    getPackageAnnotations(packageName)
-      .then(annotations => {
-        // Construct a Cloudant creds json obj
-        const cloudantCreds = {};
-        annotations.forEach(a => {
-          cloudantCreds[a.key] = a.value;
-        });
-        checkCloudantCredentials(cloudantCreds);
-        resolve(cloudantCreds);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Verifies that cloudant creds contain all the keys
- *  necessary for db operations.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function checkCloudantCredentials(cloudantCreds) {
-  // Verify that all required Cloudant credentials are present.
-  assert(
-    cloudantCreds[CLOUDANT_URL],
-    'cloudant_url absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_DBNAME],
-    'cloudant_auth_dbname absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_KEY],
-    'cloudant_auth_key absent in cloudant credentials.'
-  );
-}
-
-/**
- *  Loads the auth info from the Cloudant auth db
- *  using supplied Cloudant credentials.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *
- *  @return auth information loaded from Cloudant
- *  eg:
- *   {
- *     "conversation": {
- *       "password": "xxxxxx",
- *       "username": "xxxxxx",
- *       "workspace_id": "xxxxxx"
- *     },
- *     "facebook": {
- *       "app_secret": "xxxxxx",
- *       "page_access_token": "xxxxxx",
- *       "verification_token": "xxxxxx"
- *     },
- *     "slack": {
- *       "client_id": "xxxxxx",
- *       "client_secret": "xxxxxx",
- *       "verification_token": "xxxxxx",
- *       "access_token": "xxxxxx",
- *       "bot_access_token": "xxxxxx"
- *     }
- *   }
- */
-function loadAuth(cloudantCreds) {
-  return new Promise((resolve, reject) => {
-    const cloudantUrl = cloudantCreds[CLOUDANT_URL];
-    const cloudantAuthDbName = cloudantCreds[CLOUDANT_AUTH_DBNAME];
-    const cloudantAuthKey = cloudantCreds[CLOUDANT_AUTH_KEY];
-
-    createCloudantObj(cloudantUrl)
-      .then(cloudantObj => {
-        return retrieveDoc(
-          cloudantObj.use(cloudantAuthDbName),
-          cloudantAuthKey
-        );
-      })
-      .then(auth => {
-        resolve(auth);
-      })
-      .catch(err => {
-        reject(err);
-      });
-  });
-}
-
-/**
- * Creates the Cloudant object using the Cloudant url specified
- *
- *  @cloudantUrl - {string} Cloudant url linked to the
- *                 user's Cloudant instance.
- *
- * @return Cloudant object or, rejects with the exception from Cloudant
- */
-function createCloudantObj(cloudantUrl) {
-  return new Promise((resolve, reject) => {
-    try {
-      const cloudant = Cloudant({
-        url: cloudantUrl,
-        plugin: 'retry',
-        retryAttempts: 5,
-        retryTimeout: 1000
-      });
-      resolve(cloudant);
-    } catch (err) {
-      reject(err);
-    }
-  });
-}
-
-/**
- * Retrieves the doc from the Cloudant db using the key provided.
- *
- *  @db - {Object} Cloudant db object
- *  @key - {string} key to use for retrieving doc
- *
- *  @return doc or, rejects with an exception from Cloudant
- */
-function retrieveDoc(db, key) {
-  return new Promise((resolve, reject) => {
-    db.get(
-      key,
-      {
-        // We need to add revision ids to prevent Cloudant update conflicts during writes
-        revs_info: true
-      },
-      (error, response) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(response);
-      }
-    );
-  });
-}
-
-/**
- *  Gets the annotations for the package specified.
- *
- *  @packageName  {string} Name of the package whose annotations are needed
- *
- *  @return - package annotations array
- *  eg: [
- *     {
- *       key: 'cloudant_url',
- *       value: 'https://some-cloudant-url'
- *     },
- *     {
- *       key: 'cloudant_auth_dbname',
- *       value: 'authdb'
- *     },
- *     {
- *       key: 'cloudant_auth_key',
- *       value: '123456'
- *     }
- *   ]
- */
-function getPackageAnnotations(packageName) {
-  return new Promise((resolve, reject) => {
-    openwhisk().packages
-      .get(packageName)
-      .then(pkg => {
-        resolve(pkg.annotations);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Gets the package name from the action name that lives in it.
- *
- *  @actionName  {string} Full name of the action from which
- *               package name is to be extracted.
- *
- *  @return - package name
- *  eg: full action name = '/org_space/pkg/action' then,
- *      package name = 'pkg'
- */
-function extractCurrentPackageName(actionName) {
-  return actionName.split('/')[2];
 }
 
 /**
@@ -350,6 +137,12 @@ function validateParameters(params) {
 
   // Required: Message to send
   assert(params.text, 'Message text not provided.');
+
+  // Required: auth
+  assert(
+    params.raw_input_data && params.raw_input_data.auth,
+    'No raw_input_data.auth found.'
+  );
 }
 
 /**
@@ -372,10 +165,5 @@ module.exports = {
   main,
   name: 'slack/post',
   validateParameters,
-  postSlack,
-  loadAuth,
-  createCloudantObj,
-  getCloudantCreds,
-  checkCloudantCredentials,
-  retrieveDoc
+  postSlack
 };

--- a/channels/slack/receive/index.js
+++ b/channels/slack/receive/index.js
@@ -58,7 +58,7 @@ function main(params) {
         if (isDuplicateMessage(params)) {
           reject(extractSlackParameters(params));
         } else {
-          resolve(extractSlackParameters(params));
+          resolve(addAuthToParams(extractSlackParameters(params), auth));
         }
       })
       .catch(err => {
@@ -68,6 +68,10 @@ function main(params) {
         });
       });
   });
+}
+
+function addAuthToParams(params, auth) {
+  return Object.assign({ auth }, params);
 }
 
 /**

--- a/conversation/call-conversation.js
+++ b/conversation/call-conversation.js
@@ -17,12 +17,6 @@
 const assert = require('assert');
 
 const ConversationV1 = require('watson-developer-cloud/conversation/v1');
-const Cloudant = require('cloudant');
-const openwhisk = require('openwhisk');
-
-const CLOUDANT_URL = 'cloudant_url';
-const CLOUDANT_AUTH_DBNAME = 'cloudant_auth_dbname';
-const CLOUDANT_AUTH_KEY = 'cloudant_auth_key';
 
 /**
  *
@@ -52,49 +46,44 @@ function main(params) {
   return new Promise((resolve, reject) => {
     validateParams(params);
 
-    getCloudantCreds()
-      .then(cloudantCreds => {
-        return loadAuth(cloudantCreds);
-      })
-      .then(auth => {
-        assert(auth.conversation, 'conversation object absent in auth data.');
-        assert(
-          auth.conversation.username,
-          'conversation username absent in auth.conversation'
-        );
-        assert(
-          auth.conversation.password,
-          'conversation password absent in auth.conversation'
-        );
-        assert(
-          auth.conversation.workspace_id,
-          'conversation workspace_id absent in auth.conversation'
-        );
+    const auth = params.raw_input_data.auth;
 
-        const conversation = new ConversationV1({
-          username: auth.conversation.username,
-          password: auth.conversation.password,
-          url: params.url,
-          version: params.version || 'v1',
-          version_date: params.version_date || '2017-05-26'
-        });
-        const payload = Object.assign({}, params.conversation);
-        payload.workspace_id = auth.conversation.workspace_id;
+    assert(auth.conversation, 'conversation object absent in auth data.');
+    assert(
+      auth.conversation.username,
+      'conversation username absent in auth.conversation'
+    );
+    assert(
+      auth.conversation.password,
+      'conversation password absent in auth.conversation'
+    );
+    assert(
+      auth.conversation.workspace_id,
+      'conversation workspace_id absent in auth.conversation'
+    );
 
-        conversation.message(payload, (err, response) => {
-          if (err) {
-            reject(err);
-          } else {
-            const conversationOutput = {
-              conversation: response,
-              raw_input_data: params.raw_input_data
-            };
-            conversationOutput.raw_input_data.conversation = params.conversation;
-            resolve(conversationOutput);
-          }
-        });
-      })
-      .catch(reject);
+    const conversation = new ConversationV1({
+      username: auth.conversation.username,
+      password: auth.conversation.password,
+      url: params.url,
+      version: params.version || 'v1',
+      version_date: params.version_date || '2017-05-26'
+    });
+    const payload = Object.assign({}, params.conversation);
+    payload.workspace_id = auth.conversation.workspace_id;
+
+    conversation.message(payload, (err, response) => {
+      if (err) {
+        reject(err);
+      } else {
+        const conversationOutput = {
+          conversation: response,
+          raw_input_data: params.raw_input_data
+        };
+        conversationOutput.raw_input_data.conversation = params.conversation;
+        resolve(conversationOutput);
+      }
+    });
   });
 }
 
@@ -118,218 +107,13 @@ function validateParams(params) {
       params.raw_input_data[params.raw_input_data.provider],
     'No channel raw input data found.'
   );
-}
 
-/**
- *  Gets the annotations for the package specified.
- *
- *  @packageName  {string} Name of the package whose annotations are needed
- *
- *  @return - package annotations array
- *  eg: [
- *     {
- *       key: 'cloudant_url',
- *       value: 'https://some-cloudant-url'
- *     },
- *     {
- *       key: 'cloudant_auth_dbname',
- *       value: 'authdb'
- *     },
- *     {
- *       key: 'cloudant_auth_key',
- *       value: '123456'
- *     }
- *   ]
- */
-function getPackageAnnotations(packageName) {
-  return new Promise((resolve, reject) => {
-    openwhisk().packages
-      .get(packageName)
-      .then(pkg => {
-        resolve(pkg.annotations);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Gets the package name from the action name that lives in it.
- *
- *  @actionName  {string} Full name of the action from which
- *               package name is to be extracted.
- *
- *  @return - package name
- *  eg: full action name = '/org_space/pkg/action' then,
- *      package name = 'pkg'
- */
-function extractCurrentPackageName(actionName) {
-  return actionName.split('/')[2];
-}
-
-/**
- *  Gets the cloudant credentials (saved as package annotations)
- *  from the current action's full name, derived from
- *  the env var "__OW_ACTION_NAME".
- *
- *  @return - cloudant credentials to use for db read/write operations.
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function getCloudantCreds() {
-  return new Promise((resolve, reject) => {
-    // Get annotations of the current package.
-    const packageName = extractCurrentPackageName(process.env.__OW_ACTION_NAME);
-    getPackageAnnotations(packageName)
-      .then(annotations => {
-        // Construct a Cloudant creds json obj
-        const cloudantCreds = {};
-        annotations.forEach(a => {
-          cloudantCreds[a.key] = a.value;
-        });
-        checkCloudantCredentials(cloudantCreds);
-        resolve(cloudantCreds);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Verifies that cloudant creds contain all the keys
- *  necessary for db operations.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function checkCloudantCredentials(cloudantCreds) {
-  // Verify that all required Cloudant credentials are present.
-  assert(
-    cloudantCreds[CLOUDANT_URL],
-    'cloudant_url absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_DBNAME],
-    'cloudant_auth_dbname absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_KEY],
-    'cloudant_auth_key absent in cloudant credentials.'
-  );
-}
-
-/**
- *  Loads the auth info from the Cloudant auth db
- *  using supplied Cloudant credentials.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *
- *  @return auth information loaded from Cloudant
- *  eg:
- *   {
- *     "conversation": {
- *       "password": "xxxxxx",
- *       "username": "xxxxxx",
- *       "workspace_id": "xxxxxx"
- *     },
- *     "facebook": {
- *       "app_secret": "xxxxxx",
- *       "page_access_token": "xxxxxx",
- *       "verification_token": "xxxxxx"
- *     },
- *     "slack": {
- *       "client_id": "xxxxxx",
- *       "client_secret": "xxxxxx",
- *       "verification_token": "xxxxxx",
- *       "access_token": "xxxxxx",
- *       "bot_access_token": "xxxxxx"
- *     }
- *   }
- */
-function loadAuth(cloudantCreds) {
-  return new Promise((resolve, reject) => {
-    const cloudantUrl = cloudantCreds[CLOUDANT_URL];
-    const cloudantAuthDbName = cloudantCreds[CLOUDANT_AUTH_DBNAME];
-    const cloudantAuthKey = cloudantCreds[CLOUDANT_AUTH_KEY];
-
-    createCloudantObj(cloudantUrl)
-      .then(cloudantObj => {
-        return retrieveDoc(
-          cloudantObj.use(cloudantAuthDbName),
-          cloudantAuthKey
-        );
-      })
-      .then(auth => {
-        resolve(auth);
-      })
-      .catch(err => {
-        reject(err);
-      });
-  });
-}
-
-/**
- * Creates the Cloudant object using the Cloudant url specified
- *
- *  @cloudantUrl - {string} Cloudant url linked to the
- *                 user's Cloudant instance.
- *
- * @return Cloudant object or, rejects with the exception from Cloudant
- */
-function createCloudantObj(cloudantUrl) {
-  return new Promise((resolve, reject) => {
-    try {
-      const cloudant = Cloudant({
-        url: cloudantUrl,
-        plugin: 'retry',
-        retryAttempts: 5,
-        retryTimeout: 1000
-      });
-      resolve(cloudant);
-    } catch (err) {
-      reject(err);
-    }
-  });
-}
-
-/**
- * Retrieves the doc from the Cloudant db using the key provided.
- *
- *  @db - {Object} Cloudant db object
- *  @key - {string} key to use for retrieving doc
- *
- *  @return doc or, rejects with an exception from Cloudant
- */
-function retrieveDoc(db, key) {
-  return new Promise((resolve, reject) => {
-    db.get(
-      key,
-      {
-        // We need to add revision ids to prevent Cloudant update conflicts during writes
-        revs_info: true
-      },
-      (error, response) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(response);
-      }
-    );
-  });
+  // Required: auth
+  assert(params.raw_input_data.auth, 'No auth found.');
 }
 
 module.exports = {
   main,
   name: 'conversation/call-conversation',
-  validateParams,
-  loadAuth,
-  createCloudantObj,
-  getCloudantCreds,
-  checkCloudantCredentials,
-  retrieveDoc
+  validateParams
 };

--- a/deploy/populate-actions.js
+++ b/deploy/populate-actions.js
@@ -86,7 +86,7 @@ function main(params) {
         );
       })
       .then(result => {
-        cloudantAccount = result.response.result.message;
+        cloudantAccount = result.message;
       })
       .then(() => {
         return updateAllPackages(

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -5,6 +5,6 @@ export WSK=${WSK-wsk}
 ${WSK} action update create-cloudant-lite-instance create-cloudant-lite-instance.js > /dev/null
 ${WSK} action update create-cloudant-database create-cloudant-database.js > /dev/null
 ${WSK} action update update-auth-document update-auth-document.js > /dev/null
-${WSK} action update check-deploy-exists check-deploy-exists.js --web true > /dev/null
-${WSK} action update populate-actions populate-actions.js --web true > /dev/null
-${WSK} action update verify-slack channels/slack/verify-slack.js --web true > /dev/null
+${WSK} action update check-deploy-exists check-deploy-exists.js -a web-export true > /dev/null
+${WSK} action update populate-actions populate-actions.js -a web-export true > /dev/null
+${WSK} action update verify-slack channels/slack/verify-slack.js -a web-export true > /dev/null

--- a/starter-code/normalize-for-conversation/normalize-facebook-for-conversation.js
+++ b/starter-code/normalize-for-conversation/normalize-facebook-for-conversation.js
@@ -18,13 +18,6 @@
 
 const assert = require('assert');
 
-const Cloudant = require('cloudant');
-const openwhisk = require('openwhisk');
-
-const CLOUDANT_URL = 'cloudant_url';
-const CLOUDANT_AUTH_DBNAME = 'cloudant_auth_dbname';
-const CLOUDANT_AUTH_KEY = 'cloudant_auth_key';
-
 /**
  * Converts facebook channel-formatted JSON data into Conversation SDK formatted JSON input.
  *
@@ -44,16 +37,10 @@ const CLOUDANT_AUTH_KEY = 'cloudant_auth_key';
 function main(params) {
   return new Promise((resolve, reject) => {
     validateParameters(params);
-    let authData;
 
-    getCloudantCreds()
-      .then(creds => {
-        return loadAuth(creds);
-      })
-      .then(auth => {
-        authData = auth;
-        return getTextFromPayload(params);
-      })
+    const auth = params.auth;
+
+    getTextFromPayload(params)
       .then(result => {
         const conversationJson = {
           conversation: {
@@ -64,11 +51,12 @@ function main(params) {
           raw_input_data: {
             facebook: params.facebook,
             provider: 'facebook',
+            auth,
             // This cloudant_key lives till context/saveContext so the action can perform
             // operations in the Cloudant db.
             // Other channels must add a similar parameter
             // which uniquely identifies a conversation for a user.
-            cloudant_context_key: generateCloudantKey(params, authData)
+            cloudant_context_key: generateCloudantKey(params, auth)
           }
         };
         resolve(conversationJson);
@@ -121,6 +109,8 @@ function validateParameters(params) {
   assert(params.provider, "Provider not supplied or isn't Facebook.");
   // Required: JSON data for the channel provider must be supplied
   assert(params.facebook, 'Facebook JSON data is missing.');
+  // Required: auth
+  assert(params.auth, 'No auth found.');
 }
 
 /**
@@ -141,216 +131,8 @@ function generateCloudantKey(params, auth) {
   return `facebook_${fbSenderId}_${fbWorkspaceId}_${fbRecipientId}`;
 }
 
-/**
- *  Gets the annotations for the package specified.
- *
- *  @packageName  {string} Name of the package whose annotations are needed
- *
- *  @return - package annotations array
- *  eg: [
- *     {
- *       key: 'cloudant_url',
- *       value: 'https://some-cloudant-url'
- *     },
- *     {
- *       key: 'cloudant_auth_dbname',
- *       value: 'authdb'
- *     },
- *     {
- *       key: 'cloudant_auth_key',
- *       value: '123456'
- *     }
- *   ]
- */
-function getPackageAnnotations(packageName) {
-  return new Promise((resolve, reject) => {
-    openwhisk().packages
-      .get(packageName)
-      .then(pkg => {
-        resolve(pkg.annotations);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Gets the package name from the action name that lives in it.
- *
- *  @actionName  {string} Full name of the action from which
- *               package name is to be extracted.
- *
- *  @return - package name
- *  eg: full action name = '/org_space/pkg/action' then,
- *      package name = 'pkg'
- */
-function extractCurrentPackageName(actionName) {
-  return actionName.split('/')[2];
-}
-
-/**
- *  Gets the cloudant credentials (saved as package annotations)
- *  from the current action's full name, derived from
- *  the env var "__OW_ACTION_NAME".
- *
- *  @return - cloudant credentials to use for db read/write operations.
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function getCloudantCreds() {
-  return new Promise((resolve, reject) => {
-    // Get annotations of the current package.
-    const packageName = extractCurrentPackageName(process.env.__OW_ACTION_NAME);
-    getPackageAnnotations(packageName)
-      .then(annotations => {
-        // Construct a Cloudant creds json obj
-        const cloudantCreds = {};
-        annotations.forEach(a => {
-          cloudantCreds[a.key] = a.value;
-        });
-        checkCloudantCredentials(cloudantCreds);
-        resolve(cloudantCreds);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Verifies that cloudant creds contain all the keys
- *  necessary for db operations.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function checkCloudantCredentials(cloudantCreds) {
-  // Verify that all required Cloudant credentials are present.
-  assert(
-    cloudantCreds[CLOUDANT_URL],
-    'cloudant_url absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_DBNAME],
-    'cloudant_auth_dbname absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_KEY],
-    'cloudant_auth_key absent in cloudant credentials.'
-  );
-}
-
-/**
- *  Loads the auth info from the Cloudant auth db
- *  using supplied Cloudant credentials.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *
- *  @return auth information loaded from Cloudant
- *  eg:
- *   {
- *     "conversation": {
- *       "password": "xxxxxx",
- *       "username": "xxxxxx",
- *       "workspace_id": "xxxxxx"
- *     },
- *     "facebook": {
- *       "app_secret": "xxxxxx",
- *       "page_access_token": "xxxxxx",
- *       "verification_token": "xxxxxx"
- *     },
- *     "slack": {
- *       "client_id": "xxxxxx",
- *       "client_secret": "xxxxxx",
- *       "verification_token": "xxxxxx",
- *       "access_token": "xxxxxx",
- *       "bot_access_token": "xxxxxx"
- *     }
- *   }
- */
-function loadAuth(cloudantCreds) {
-  return new Promise((resolve, reject) => {
-    const cloudantUrl = cloudantCreds[CLOUDANT_URL];
-    const cloudantAuthDbName = cloudantCreds[CLOUDANT_AUTH_DBNAME];
-    const cloudantAuthKey = cloudantCreds[CLOUDANT_AUTH_KEY];
-
-    createCloudantObj(cloudantUrl)
-      .then(cloudantObj => {
-        return retrieveDoc(
-          cloudantObj.use(cloudantAuthDbName),
-          cloudantAuthKey
-        );
-      })
-      .then(auth => {
-        resolve(auth);
-      })
-      .catch(err => {
-        reject(err);
-      });
-  });
-}
-
-/**
- * Creates the Cloudant object using the Cloudant url specified
- *
- *  @cloudantUrl - {string} Cloudant url linked to the
- *                 user's Cloudant instance.
- *
- * @return Cloudant object or, rejects with the exception from Cloudant
- */
-function createCloudantObj(cloudantUrl) {
-  return new Promise((resolve, reject) => {
-    try {
-      const cloudant = Cloudant({
-        url: cloudantUrl,
-        plugin: 'retry',
-        retryAttempts: 5,
-        retryTimeout: 1000
-      });
-      resolve(cloudant);
-    } catch (err) {
-      reject(err);
-    }
-  });
-}
-
-/**
- * Retrieves the doc from the Cloudant db using the key provided.
- *
- *  @db - {Object} Cloudant db object
- *  @key - {string} key to use for retrieving doc
- *
- *  @return doc or, rejects with an exception from Cloudant
- */
-function retrieveDoc(db, key) {
-  return new Promise((resolve, reject) => {
-    db.get(
-      key,
-      {
-        // We need to add revision ids to prevent Cloudant update conflicts during writes
-        revs_info: true
-      },
-      (error, response) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(response);
-      }
-    );
-  });
-}
-
 module.exports = {
   main,
   name: 'starter-code/normalize-facebook-for-conversation',
-  validateParameters,
-  loadAuth,
-  createCloudantObj,
-  getCloudantCreds,
-  checkCloudantCredentials,
-  retrieveDoc
+  validateParameters
 };

--- a/starter-code/normalize-for-conversation/normalize-slack-for-conversation.js
+++ b/starter-code/normalize-for-conversation/normalize-slack-for-conversation.js
@@ -17,12 +17,7 @@
 'use strict';
 
 const assert = require('assert');
-const Cloudant = require('cloudant');
-const openwhisk = require('openwhisk');
 
-const CLOUDANT_URL = 'cloudant_url';
-const CLOUDANT_AUTH_DBNAME = 'cloudant_auth_dbname';
-const CLOUDANT_AUTH_KEY = 'cloudant_auth_key';
 /**
  * Converts Slack channel-formatted JSON data into Conversation SDK formatted JSON input.
  *
@@ -32,228 +27,21 @@ const CLOUDANT_AUTH_KEY = 'cloudant_auth_key';
 function main(params) {
   return new Promise(resolve => {
     validateParameters(params);
+    const auth = params.auth;
 
-    getCloudantCreds()
-      .then(creds => {
-        return loadAuth(creds);
-      })
-      .then(auth => {
-        resolve({
-          conversation: {
-            input: {
-              text: getSlackInputMessage(params)
-            }
-          },
-          raw_input_data: {
-            slack: params.slack,
-            provider: 'slack',
-            cloudant_context_key: generateCloudantKey(params, auth)
-          }
-        });
-      });
-  });
-}
-
-/**
- *  Gets the annotations for the package specified.
- *
- *  @packageName  {string} Name of the package whose annotations are needed
- *
- *  @return - package annotations array
- *  eg: [
- *     {
- *       key: 'cloudant_url',
- *       value: 'https://some-cloudant-url'
- *     },
- *     {
- *       key: 'cloudant_auth_dbname',
- *       value: 'authdb'
- *     },
- *     {
- *       key: 'cloudant_auth_key',
- *       value: '123456'
- *     }
- *   ]
- */
-function getPackageAnnotations(packageName) {
-  return new Promise((resolve, reject) => {
-    openwhisk().packages
-      .get(packageName)
-      .then(pkg => {
-        resolve(pkg.annotations);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Gets the package name from the action name that lives in it.
- *
- *  @actionName  {string} Full name of the action from which
- *               package name is to be extracted.
- *
- *  @return - package name
- *  eg: full action name = '/org_space/pkg/action' then,
- *      package name = 'pkg'
- */
-function extractCurrentPackageName(actionName) {
-  return actionName.split('/')[2];
-}
-
-/**
- *  Gets the cloudant credentials (saved as package annotations)
- *  from the current action's full name, derived from
- *  the env var "__OW_ACTION_NAME".
- *
- *  @return - cloudant credentials to use for db read/write operations.
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function getCloudantCreds() {
-  return new Promise((resolve, reject) => {
-    // Get annotations of the current package.
-    const packageName = extractCurrentPackageName(process.env.__OW_ACTION_NAME);
-    getPackageAnnotations(packageName)
-      .then(annotations => {
-        // Construct a Cloudant creds json obj
-        const cloudantCreds = {};
-        annotations.forEach(a => {
-          cloudantCreds[a.key] = a.value;
-        });
-        checkCloudantCredentials(cloudantCreds);
-        resolve(cloudantCreds);
-      })
-      .catch(reject);
-  });
-}
-
-/**
- *  Verifies that cloudant creds contain all the keys
- *  necessary for db operations.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *  eg: {
- *       cloudant_url: 'https://some-cloudant-url.com',
- *       cloudant_auth_dbname: 'abc',
- *       cloudant_auth_key: '123'
- *     };
- */
-function checkCloudantCredentials(cloudantCreds) {
-  // Verify that all required Cloudant credentials are present.
-  assert(
-    cloudantCreds[CLOUDANT_URL],
-    'cloudant_url absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_DBNAME],
-    'cloudant_auth_dbname absent in cloudant credentials.'
-  );
-  assert(
-    cloudantCreds[CLOUDANT_AUTH_KEY],
-    'cloudant_auth_key absent in cloudant credentials.'
-  );
-}
-
-/**
- *  Loads the auth info from the Cloudant auth db
- *  using supplied Cloudant credentials.
- *
- *  @cloudantCreds - {JSON} Cloudant credentials JSON
- *
- *  @return auth information loaded from Cloudant
- *  eg:
- *   {
- *     "conversation": {
- *       "password": "xxxxxx",
- *       "username": "xxxxxx",
- *       "workspace_id": "xxxxxx"
- *     },
- *     "facebook": {
- *       "app_secret": "xxxxxx",
- *       "page_access_token": "xxxxxx",
- *       "verification_token": "xxxxxx"
- *     },
- *     "slack": {
- *       "client_id": "xxxxxx",
- *       "client_secret": "xxxxxx",
- *       "verification_token": "xxxxxx",
- *       "access_token": "xxxxxx",
- *       "bot_access_token": "xxxxxx"
- *     }
- *   }
- */
-function loadAuth(cloudantCreds) {
-  return new Promise((resolve, reject) => {
-    const cloudantUrl = cloudantCreds[CLOUDANT_URL];
-    const cloudantAuthDbName = cloudantCreds[CLOUDANT_AUTH_DBNAME];
-    const cloudantAuthKey = cloudantCreds[CLOUDANT_AUTH_KEY];
-
-    createCloudantObj(cloudantUrl)
-      .then(cloudantObj => {
-        return retrieveDoc(
-          cloudantObj.use(cloudantAuthDbName),
-          cloudantAuthKey
-        );
-      })
-      .then(auth => {
-        resolve(auth);
-      })
-      .catch(err => {
-        reject(err);
-      });
-  });
-}
-
-/**
- * Creates the Cloudant object using the Cloudant url specified
- *
- *  @cloudantUrl - {string} Cloudant url linked to the
- *                 user's Cloudant instance.
- *
- * @return Cloudant object or, rejects with the exception from Cloudant
- */
-function createCloudantObj(cloudantUrl) {
-  return new Promise((resolve, reject) => {
-    try {
-      const cloudant = Cloudant({
-        url: cloudantUrl,
-        plugin: 'retry',
-        retryAttempts: 5,
-        retryTimeout: 1000
-      });
-      resolve(cloudant);
-    } catch (err) {
-      reject(err);
-    }
-  });
-}
-
-/**
- * Retrieves the doc from the Cloudant db using the key provided.
- *
- *  @db - {Object} Cloudant db object
- *  @key - {string} key to use for retrieving doc
- *
- *  @return doc or, rejects with an exception from Cloudant
- */
-function retrieveDoc(db, key) {
-  return new Promise((resolve, reject) => {
-    db.get(
-      key,
-      {
-        // We need to add revision ids to prevent Cloudant update conflicts during writes
-        revs_info: true
-      },
-      (error, response) => {
-        if (error) {
-          reject(error);
+    resolve({
+      conversation: {
+        input: {
+          text: getSlackInputMessage(params)
         }
-        resolve(response);
+      },
+      raw_input_data: {
+        slack: params.slack,
+        provider: 'slack',
+        auth,
+        cloudant_context_key: generateCloudantKey(params, auth)
       }
-    );
+    });
   });
 }
 
@@ -388,15 +176,13 @@ function validateParameters(params) {
           payloadAction.selected_options[0].value));
   }
   assert(slackMessage, 'No Slack message text provided.');
+
+  // Required: auth
+  assert(params.auth, 'No auth found.');
 }
 
 module.exports = {
   main,
   name: 'starter-code/normalize-slack-for-conversation',
-  validateParameters,
-  loadAuth,
-  createCloudantObj,
-  getCloudantCreds,
-  checkCloudantCredentials,
-  retrieveDoc
+  validateParameters
 };

--- a/test/end-to-end/test.end-to-end.with-facebook.js
+++ b/test/end-to-end/test.end-to-end.with-facebook.js
@@ -227,7 +227,7 @@ describe('End-to-End tests: Facebook as channel package - for batched messages',
   const expectedBatchedResult = {
     failedActionInvocations: [
       {
-        errorMessage: 'Recipient id: 185643828639058 , Sender id: undefined -- Action invocation failed, API returned error code. Check syntax errors? No Facebook sender_id found in raw data.',
+        errorMessage: 'Recipient id: 185643828639058 , Sender id: undefined -- POST https://openwhisk.ng.bluemix.net:443/api/v1/namespaces/foropenwhisk_prod/actions/test-pipeline-facebook Returned HTTP 502 (Bad Gateway) --> "No Facebook sender_id found in raw data."',
         activationId: ''
       }
     ],

--- a/test/integration/channels/facebook/middle.js
+++ b/test/integration/channels/facebook/middle.js
@@ -40,7 +40,10 @@ function main(params) {
     recipient: {
       id: params.facebook.sender.id
     },
-    message: params.facebook.message
+    message: params.facebook.message,
+    raw_input_data: {
+      auth: params.auth
+    }
   };
 }
 
@@ -57,6 +60,11 @@ function validateParams(params) {
   // Required: The parameters of the channel provider
   if (!params.facebook) {
     throw new Error('No facebook data or event parameters provided.');
+  }
+
+  // Required: Auth
+  if (!params.auth) {
+    throw new Error('No auth provided.');
   }
 }
 

--- a/test/integration/channels/facebook/test.channel.facebook.js
+++ b/test/integration/channels/facebook/test.channel.facebook.js
@@ -102,7 +102,7 @@ describe('Facebook channel integration tests', () => {
   const expectedBatchedResult = {
     failedActionInvocations: [
       {
-        errorMessage: 'Recipient id: 185643828639058 , Sender id: undefined -- Action invocation failed, API returned error code. Check syntax errors? Recepient id not provided.',
+        errorMessage: 'Recipient id: 185643828639058 , Sender id: undefined -- POST https://openwhisk.ng.bluemix.net:443/api/v1/namespaces/foropenwhisk_prod/actions/testflex_facebook/integration-pipeline Returned HTTP 502 (Bad Gateway) --> "Recepient id not provided."',
         activationId: ''
       }
     ],

--- a/test/integration/channels/slack/send-attached-message-response.js
+++ b/test/integration/channels/slack/send-attached-message-response.js
@@ -28,6 +28,7 @@ const assert = require('assert');
 function main(params) {
   return new Promise(resolve => {
     validateParameters(params);
+    const auth = params.auth;
 
     const payload = JSON.parse(params.slack.payload);
 
@@ -38,7 +39,11 @@ function main(params) {
         {
           text: 'Message coming from Slack integration test.'
         }
-      ]
+      ],
+      raw_input_data: {
+        provider: 'slack',
+        auth
+      }
     });
   });
 }
@@ -71,6 +76,9 @@ function validateParameters(params) {
 
   // Required: Slack original message
   assert(payload.original_message, 'No Slack original message provided.');
+
+  // Required: auth
+  assert(params.auth, 'No auth provided.');
 }
 
 module.exports = main;

--- a/test/integration/channels/slack/send-attached-message.js
+++ b/test/integration/channels/slack/send-attached-message.js
@@ -28,6 +28,7 @@ const assert = require('assert');
 function main(params) {
   return new Promise(resolve => {
     validateParameters(params);
+    const auth = params.auth;
 
     const attachments = [
       {
@@ -59,7 +60,11 @@ function main(params) {
     resolve({
       channel: params.slack.event.channel,
       text: params.slack.event.text,
-      attachments
+      attachments,
+      raw_input_data: {
+        provider: 'slack',
+        auth
+      }
     });
   });
 }
@@ -87,6 +92,9 @@ function validateParameters(params) {
 
   // Required: Slack input text
   assert(params.slack.event.text, 'No Slack input text provided.');
+
+  // Required: auth
+  assert(params.auth, 'No auth provided.');
 }
 
 module.exports = main;

--- a/test/integration/channels/slack/send-text.js
+++ b/test/integration/channels/slack/send-text.js
@@ -28,10 +28,15 @@ const assert = require('assert');
 function main(params) {
   return new Promise(resolve => {
     validateParameters(params);
+    const auth = params.auth;
 
     resolve({
       channel: params.slack.event.channel,
-      text: params.slack.event.text
+      text: params.slack.event.text,
+      raw_input_data: {
+        provider: 'slack',
+        auth
+      }
     });
   });
 }
@@ -59,6 +64,9 @@ function validateParameters(params) {
 
   // Required: Slack input text
   assert(params.slack.event.text, 'No Slack input text provided.');
+
+  // Required: Auth
+  assert(params.auth, 'No auth provided.');
 }
 
 module.exports = main;

--- a/test/integration/conversation/test.conversation.js
+++ b/test/integration/conversation/test.conversation.js
@@ -42,7 +42,14 @@ describe('conversation integration tests', () => {
             text: 'Turn on lights'
           }
         },
-        provider: 'slack'
+        provider: 'slack',
+        auth: {
+          conversation: {
+            username: envParams.__TEST_CONVERSATION_USERNAME,
+            password: envParams.__TEST_CONVERSATION_PASSWORD,
+            workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
+          }
+        }
       }
     };
 

--- a/test/integration/deploy/channels/slack/test.verify-slack.js
+++ b/test/integration/deploy/channels/slack/test.verify-slack.js
@@ -27,7 +27,7 @@ const openwhisk = require('openwhisk');
 const actionPopulateActions = 'populate-actions';
 const actionVerifySlack = 'verify-slack';
 
-describe('deploy verify-slack intergration tests', () => {
+describe('deploy verify-slack integration tests', () => {
   const ow = openwhisk();
 
   let params;

--- a/test/integration/starter-code/test.starter-code.facebook.js
+++ b/test/integration/starter-code/test.starter-code.facebook.js
@@ -33,6 +33,13 @@ describe('starter-code integration tests for facebook', () => {
   let params;
   let expectedResult;
   let facebookData;
+  const auth = {
+    conversation: {
+      username: envParams.__TEST_CONVERSATION_USERNAME,
+      password: envParams.__TEST_CONVERSATION_PASSWORD,
+      workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
+    }
+  };
 
   beforeEach(() => {
     params = {
@@ -47,7 +54,8 @@ describe('starter-code integration tests for facebook', () => {
           text: 'hello, world!'
         }
       },
-      provider: 'facebook'
+      provider: 'facebook',
+      auth
     };
 
     expectedResult = {
@@ -57,6 +65,7 @@ describe('starter-code integration tests for facebook', () => {
       raw_input_data: {
         facebook: params.facebook,
         provider: 'facebook',
+        auth,
         cloudant_context_key: 'facebook_1481847138543615_e808d814-9143-4dce-aec7-68af02e650a8_185643828639058',
         conversation: { input: { text: 'hello, world!' } }
       },

--- a/test/integration/starter-code/test.starter-code.slack.js
+++ b/test/integration/starter-code/test.starter-code.slack.js
@@ -39,6 +39,13 @@ describe('starter-code integration tests for slack', () => {
   let params;
   let expectedResult;
   let slackData;
+  const auth = {
+    conversation: {
+      username: envParams.__TEST_CONVERSATION_USERNAME,
+      password: envParams.__TEST_CONVERSATION_PASSWORD,
+      workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
+    }
+  };
 
   beforeEach(() => {
     params = {
@@ -59,6 +66,7 @@ describe('starter-code integration tests for slack', () => {
         event_time: 1234567890
       },
       provider: 'slack',
+      auth,
       channel_id: 'D024BE91L',
       message: inputText,
       context: {}
@@ -77,6 +85,7 @@ describe('starter-code integration tests for slack', () => {
         },
         slack: params.slack,
         provider: 'slack',
+        auth,
         cloudant_context_key: 'slack_TXXXXXXXX_e808d814-9143-4dce-aec7-68af02e650a8_U2147483697_D024BE91L'
       },
       raw_output_data: {

--- a/test/scripts/run_tests.sh
+++ b/test/scripts/run_tests.sh
@@ -125,6 +125,7 @@ createCloudantInstanceDatabases() {
       break
     fi
   done
+  export __TEST_CLOUDANT_URL="${CLOUDANT_URL}"
   echo 'Created Cloudant Auth and Context dbs.'
 }
 
@@ -165,7 +166,8 @@ createWhiskArtifacts() {
   cd starter-code; ./setup.sh "${__TEST_PIPELINE_NAME}_"; cd ..
   cd conversation; ./setup.sh "${__TEST_PIPELINE_NAME}_"; cd ..
   cd context; ./setup.sh "${__TEST_PIPELINE_NAME}_"; cd ..
-
+  cd deploy; ./setup.sh; cd ..
+  
   cd channels;
   cd facebook; ./setup.sh "${__TEST_PIPELINE_NAME}_"; cd ..
   cd slack; ./setup.sh "${__TEST_PIPELINE_NAME}_"; cd ..;cd ..;
@@ -275,7 +277,7 @@ destroyWhiskArtifactsAndDatabases() {
 
 runTestSuite() {
   # Run tests with coverage
-  istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive -s 5000 -t 10000 -R spec
+  istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive -s 5000 -t 20000 -R spec
   RETCODE=$?
 }
 

--- a/test/unit/authdb/test.load-auth.js
+++ b/test/unit/authdb/test.load-auth.js
@@ -28,26 +28,10 @@ process.env.__OW_ACTION_NAME = `/${process.env.__OW_NAMESPACE}/pipeline_pkg/acti
 
 const actionSlackDeploy = require('./../../../channels/slack/deploy/index.js');
 const actionSlackReceive = require('./../../../channels/slack/receive/index.js');
-const actionSlackPost = require('./../../../channels/slack/post/index.js');
 
-const actionFacebookPost = require('./../../../channels/facebook/post/index.js');
 const actionFacebookReceive = require('./../../../channels/facebook/receive/index.js');
 
-const actionCallConversation = require('./../../../conversation/call-conversation.js');
-
-const actionStarterCodeNormSlackForConv = require('./../../../starter-code/normalize-for-conversation/normalize-slack-for-conversation.js');
-const actionStarterCodeNormFacebookForConv = require('./../../../starter-code/normalize-for-conversation/normalize-facebook-for-conversation.js');
-
-const actions = [
-  actionSlackDeploy,
-  actionSlackReceive,
-  actionSlackPost,
-  actionFacebookPost,
-  actionFacebookReceive,
-  actionCallConversation,
-  actionStarterCodeNormSlackForConv,
-  actionStarterCodeNormFacebookForConv
-];
+const actions = [actionSlackDeploy, actionSlackReceive, actionFacebookReceive];
 
 const errorNoCloudantUrl = 'cloudant_url absent in cloudant credentials.';
 const errorNoCloudantAuthDbName = 'cloudant_auth_dbname absent in cloudant credentials.';

--- a/test/unit/channels/slack/test.channel.slack.receive.js
+++ b/test/unit/channels/slack/test.channel.slack.receive.js
@@ -38,7 +38,7 @@ describe('Slack Receive Unit Tests', () => {
   let messageResult;
   let payloadParams;
   let payloadResult;
-  let auth;
+
   const incorrectToken = 'incorrect_token';
 
   let func = slackReceive.main;
@@ -54,6 +54,14 @@ describe('Slack Receive Unit Tests', () => {
   let owMock;
   const owHost = `https://${apiHost}`;
   let cloudantMock;
+
+  const auth = {
+    slack: {
+      client_id: envParams.__TEST_SLACK_CLIENT_ID,
+      client_secret: envParams.__TEST_SLACK_CLIENT_SECRET,
+      verification_token: envParams.__TEST_SLACK_VERIFICATION_TOKEN
+    }
+  };
 
   before(() => {
     process.env.__OW_ACTION_NAME = `/${envParams.__OW_NAMESPACE}/pipeline_pkg/action-to-test`;
@@ -81,7 +89,8 @@ describe('Slack Receive Unit Tests', () => {
           channel: envParams.__TEST_SLACK_CHANNEL
         }
       },
-      provider: 'slack'
+      provider: 'slack',
+      auth
     };
 
     challengeParams = {
@@ -115,15 +124,8 @@ describe('Slack Receive Unit Tests', () => {
       slack: {
         payload: JSON.stringify(payload)
       },
-      provider: 'slack'
-    };
-
-    auth = {
-      slack: {
-        client_id: envParams.__TEST_SLACK_CLIENT_ID,
-        client_secret: envParams.__TEST_SLACK_CLIENT_SECRET,
-        verification_token: envParams.__TEST_SLACK_VERIFICATION_TOKEN
-      }
+      provider: 'slack',
+      auth
     };
 
     nock.cleanAll();
@@ -251,6 +253,7 @@ describe('Slack Receive Unit Tests', () => {
       'x-slack-retry-num': 1
     };
     func = slackReceive.main;
+    delete messageResult.auth;
 
     return func(messageParams).then(
       () => {

--- a/test/unit/conversation/test.conversation.js
+++ b/test/unit/conversation/test.conversation.js
@@ -40,21 +40,8 @@ const conversationErrorMsg = 'Internal Server Error';
 describe('conversation unit tests', () => {
   let params = {};
   let func;
-  let auth;
-
-  const cloudantUrl = 'https://some-cloudant-url.com';
-  const cloudantAuthDbName = 'abc';
-  const cloudantAuthKey = '123';
-
-  const apiHost = process.env.__OW_API_HOST;
-  const namespace = process.env.__OW_NAMESPACE;
-  const packageName = process.env.__OW_ACTION_NAME.split('/')[2];
 
   const conversationUrl = 'https://ibm.com:80';
-
-  let owMock;
-  const owHost = `https://${apiHost}`;
-  let cloudantMock;
 
   const conversationResponse = {
     intents: [],
@@ -113,6 +100,13 @@ describe('conversation unit tests', () => {
         }
       },
       provider: 'slack',
+      auth: {
+        conversation: {
+          username: envParams.__TEST_CONVERSATION_USERNAME,
+          password: envParams.__TEST_CONVERSATION_PASSWORD,
+          workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
+        }
+      },
       conversation: {
         input: {
           text: 'Turn on lights'
@@ -140,21 +134,18 @@ describe('conversation unit tests', () => {
             text: 'Turn on lights'
           }
         },
-        provider: 'slack'
-      }
-    };
-
-    auth = {
-      conversation: {
-        username: envParams.__TEST_CONVERSATION_USERNAME,
-        password: envParams.__TEST_CONVERSATION_PASSWORD,
-        workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
+        provider: 'slack',
+        auth: {
+          conversation: {
+            username: envParams.__TEST_CONVERSATION_USERNAME,
+            password: envParams.__TEST_CONVERSATION_PASSWORD,
+            workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
+          }
+        }
       }
     };
 
     nock.cleanAll();
-    owMock = createCloudFunctionsMock();
-    cloudantMock = createCloudantMock();
     createConversationUrlMock();
   });
 
@@ -193,14 +184,6 @@ describe('conversation unit tests', () => {
 
     return func(params).then(
       result => {
-        if (!cloudantMock.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!owMock.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock OW Get server did not get called.');
-        }
         assert.deepEqual(result, expected);
       },
       error => {
@@ -218,12 +201,6 @@ describe('conversation unit tests', () => {
 
     return func(params).then(
       result => {
-        if (!cloudantMock.isDone()) {
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!owMock.isDone()) {
-          assert(false, 'Mock OW Get server did not get called.');
-        }
         assert.deepEqual(result, expected);
       },
       error => {
@@ -238,12 +215,6 @@ describe('conversation unit tests', () => {
 
     return func(params).then(
       result => {
-        if (!cloudantMock.isDone()) {
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!owMock.isDone()) {
-          assert(false, 'Mock OW Get server did not get called.');
-        }
         assert.deepEqual(result, expected);
       },
       error => {
@@ -253,18 +224,10 @@ describe('conversation unit tests', () => {
   });
 
   it('should throw AssertionError for missing conversation object in auth data', () => {
-    const badAuth = auth;
-    delete badAuth.conversation;
+    delete params.raw_input_data.auth.conversation;
 
     nock.cleanAll();
-    owMock = createCloudFunctionsMock();
     createConversationUrlMock();
-    const mockCloudantGet = nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(() => {
-        return true;
-      })
-      .reply(200, badAuth);
 
     func = conversation.main;
     return func(params)
@@ -272,30 +235,16 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(e => {
-        if (!mockCloudantGet.isDone()) {
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!owMock.isDone()) {
-          assert(false, 'Mock OW Get server did not get called.');
-        }
         assert.equal('AssertionError', e.name);
         assert.equal(errorNoConversationObjInAuth, e.message);
       });
   });
 
   it('should throw AssertionError for missing conversation username in auth data', () => {
-    const badAuth = auth;
-    delete badAuth.conversation.username;
+    delete params.raw_input_data.auth.conversation.username;
 
     nock.cleanAll();
-    owMock = createCloudFunctionsMock();
     createConversationUrlMock();
-    const mockCloudantGet = nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(() => {
-        return true;
-      })
-      .reply(200, badAuth);
 
     func = conversation.main;
     return func(params)
@@ -303,30 +252,16 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(e => {
-        if (!mockCloudantGet.isDone()) {
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!owMock.isDone()) {
-          assert(false, 'Mock OW Get server did not get called.');
-        }
         assert.equal('AssertionError', e.name);
         assert.equal(errorNoConversationUsernameInAuth, e.message);
       });
   });
 
   it('should throw AssertionError for missing conversation password in auth data', () => {
-    const badAuth = auth;
-    delete badAuth.conversation.password;
+    delete params.raw_input_data.auth.conversation.password;
 
     nock.cleanAll();
-    owMock = createCloudFunctionsMock();
     createConversationUrlMock();
-    const mockCloudantGet = nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(() => {
-        return true;
-      })
-      .reply(200, badAuth);
 
     func = conversation.main;
     return func(params)
@@ -334,30 +269,16 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(e => {
-        if (!mockCloudantGet.isDone()) {
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!owMock.isDone()) {
-          assert(false, 'Mock OW Get server did not get called.');
-        }
         assert.equal('AssertionError', e.name);
         assert.equal(errorNoConversationPassInAuth, e.message);
       });
   });
 
   it('should throw AssertionError for missing conversation workspace_id in auth data', () => {
-    const badAuth = auth;
-    delete badAuth.conversation.workspace_id;
+    delete params.raw_input_data.auth.conversation.workspace_id;
 
     nock.cleanAll();
-    owMock = createCloudFunctionsMock();
     createConversationUrlMock();
-    const mockCloudantGet = nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(() => {
-        return true;
-      })
-      .reply(200, badAuth);
 
     func = conversation.main;
     return func(params)
@@ -365,30 +286,16 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(e => {
-        if (!mockCloudantGet.isDone()) {
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!owMock.isDone()) {
-          assert(false, 'Mock OW Get server did not get called.');
-        }
         assert.equal('AssertionError', e.name);
         assert.equal(errorNoConversationWorkspaceIdInAuth, e.message);
       });
   });
 
   it('should throw Conversation error for wrong conversation workspace_id', () => {
-    const badAuth = auth;
-    badAuth.conversation.workspace_id = badWorkspaceId;
+    params.raw_input_data.auth.conversation.workspace_id = badWorkspaceId;
 
     nock.cleanAll();
-    owMock = createCloudFunctionsMock();
     createConversationUrlMock();
-    const mockCloudantGet = nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(() => {
-        return true;
-      })
-      .reply(200, badAuth);
 
     params.url = conversationUrl;
 
@@ -398,20 +305,12 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(e => {
-        if (!mockCloudantGet.isDone()) {
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!owMock.isDone()) {
-          assert(false, 'Mock OW Get server did not get called.');
-        }
         assert.equal(errorIncorrectConversationWorkspaceIdInAuth, e.message);
       });
   });
 
   it('validate error when conversation message throws error', () => {
     nock.cleanAll();
-    owMock = createCloudFunctionsMock();
-    cloudantMock = createCloudantMock();
     nock(conversationUrl)
       .post(uri => {
         return uri.indexOf(
@@ -443,79 +342,6 @@ describe('conversation unit tests', () => {
         assert.equal(error.message, mockError);
       });
   }).retries(4);
-
-  it('validate error when create cloudant object is init on null url', () => {
-    return conversation
-      .createCloudantObj(null)
-      .then(() => {
-        assert(false, 'Action succeeded unexpectedly');
-      })
-      .catch(error => {
-        assert.equal(error.message, 'invalid url');
-      });
-  });
-
-  it('validate error when retrieve doc throws an error', () => {
-    nock.cleanAll();
-    createCloudFunctionsMock();
-
-    nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(true)
-      .replyWithError({ statusCode: 400, message: mockError });
-
-    nock(`https://${cloudantUrl.split('@')[1]}`)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(true)
-      .reply(200, auth)
-      .put(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .reply(200, {});
-
-    const cloudantCreds = {
-      cloudant_url: cloudantUrl,
-      cloudant_auth_dbname: cloudantAuthDbName,
-      cloudant_auth_key: cloudantAuthKey
-    };
-
-    return conversation
-      .loadAuth(cloudantCreds)
-      .then(() => {
-        assert(false, 'Action succeeded unexpectedly.');
-      })
-      .catch(error => {
-        assert.deepEqual(error.description, mockError);
-      });
-  });
-
-  function createCloudFunctionsMock() {
-    const expectedOW = {
-      annotations: [
-        {
-          key: 'cloudant_url',
-          value: cloudantUrl
-        },
-        {
-          key: 'cloudant_auth_dbname',
-          value: cloudantAuthDbName
-        },
-        {
-          key: 'cloudant_auth_key',
-          value: cloudantAuthKey
-        }
-      ]
-    };
-
-    return nock(owHost)
-      .get(`/api/v1/namespaces/${namespace}/packages/${packageName}`)
-      .reply(200, expectedOW);
-  }
-
-  function createCloudantMock() {
-    return nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(true)
-      .reply(200, auth);
-  }
 
   function createConversationUrlMock() {
     return nock(conversationUrl)

--- a/test/unit/deploy/test.populate-actions.js
+++ b/test/unit/deploy/test.populate-actions.js
@@ -273,12 +273,7 @@ describe('Populate-Actions Unit Tests', () => {
           ) === 0;
         })
         .query(true)
-        .reply(
-          200,
-          createInvocationResult(
-            createInvocationResult({ code: 200, message: 'OK' })
-          )
-        )
+        .reply(200, createInvocationResult({ code: 200, message: 'OK' }))
     );
   }
 

--- a/test/unit/starter-code/normalize-for-conversation/test.starter-code.normalize-slack-for-conversation.js
+++ b/test/unit/starter-code/normalize-for-conversation/test.starter-code.normalize-slack-for-conversation.js
@@ -21,7 +21,6 @@
  */
 
 const assert = require('assert');
-const nock = require('nock');
 
 const envParams = process.env;
 
@@ -41,33 +40,7 @@ describe('Starter Code Normalize-Slack-For-Conversation Unit Tests', () => {
   let buttonPayload;
   let buttonMessageParams;
   let func;
-  let auth;
 
-  const cloudantUrl = 'https://some-cloudant-url.com';
-  const cloudantAuthDbName = 'abc';
-  const cloudantAuthKey = '123';
-
-  const apiHost = process.env.__OW_API_HOST;
-  const namespace = process.env.__OW_NAMESPACE;
-  const packageName = process.env.__OW_ACTION_NAME.split('/')[2];
-
-  const cloudFunctionsUrl = `https://${apiHost}/api/v1/namespaces`;
-  const expectedCloudFunctions = {
-    annotations: [
-      {
-        key: 'cloudant_url',
-        value: cloudantUrl
-      },
-      {
-        key: 'cloudant_auth_dbname',
-        value: cloudantAuthDbName
-      },
-      {
-        key: 'cloudant_auth_key',
-        value: cloudantAuthKey
-      }
-    ]
-  };
   beforeEach(() => {
     textMessageParams = {
       slack: {
@@ -87,6 +60,13 @@ describe('Starter Code Normalize-Slack-For-Conversation Unit Tests', () => {
         event_time: 1234567890
       },
       provider: 'slack',
+      auth: {
+        conversation: {
+          username: envParams.__TEST_CONVERSATION_USERNAME,
+          password: envParams.__TEST_CONVERSATION_PASSWORD,
+          workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
+        }
+      },
       context: {}
     };
 
@@ -99,6 +79,13 @@ describe('Starter Code Normalize-Slack-For-Conversation Unit Tests', () => {
       raw_input_data: {
         slack: textMessageParams.slack,
         provider: 'slack',
+        auth: {
+          conversation: {
+            username: envParams.__TEST_CONVERSATION_USERNAME,
+            password: envParams.__TEST_CONVERSATION_PASSWORD,
+            workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
+          }
+        },
         cloudant_context_key: `slack_TXXXXXXXX_${envParams.__TEST_CONVERSATION_WORKSPACE_ID}_U2147483697_CXXXXXXXXX`
       }
     };
@@ -132,39 +119,22 @@ describe('Starter Code Normalize-Slack-For-Conversation Unit Tests', () => {
         payload: JSON.stringify(buttonPayload)
       },
       provider: 'slack',
+      auth: {
+        conversation: {
+          username: envParams.__TEST_CONVERSATION_USERNAME,
+          password: envParams.__TEST_CONVERSATION_PASSWORD,
+          workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
+        }
+      },
       context: {}
-    };
-
-    auth = {
-      conversation: {
-        workspace_id: envParams.__TEST_CONVERSATION_WORKSPACE_ID
-      }
     };
   });
 
   it('validate normalizing works for a regular text message', () => {
     func = actionNormSlackForConversation.main;
-    const mockCloudFunctions = nock(cloudFunctionsUrl)
-      .get(`/${namespace}/packages/${packageName}`)
-      .reply(200, expectedCloudFunctions);
-
-    const mockCloudantGet = nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(() => {
-        return true;
-      })
-      .reply(200, auth);
 
     return func(textMessageParams).then(
       result => {
-        if (!mockCloudantGet.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!mockCloudFunctions.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock Cloud Functions Get server did not get called.');
-        }
         assert.deepEqual(result, expectedResult);
       },
       error => {
@@ -177,27 +147,9 @@ describe('Starter Code Normalize-Slack-For-Conversation Unit Tests', () => {
     expectedResult.raw_input_data.slack = buttonMessageParams.slack;
 
     func = actionNormSlackForConversation.main;
-    const mockCloudFunctions = nock(cloudFunctionsUrl)
-      .get(`/${namespace}/packages/${packageName}`)
-      .reply(200, expectedCloudFunctions);
-
-    const mockCloudantGet = nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(() => {
-        return true;
-      })
-      .reply(200, auth);
 
     return func(buttonMessageParams).then(
       result => {
-        if (!mockCloudantGet.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!mockCloudFunctions.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock Cloud Functions Get server did not get called.');
-        }
         assert.deepEqual(result, expectedResult);
       },
       error => {
@@ -220,27 +172,9 @@ describe('Starter Code Normalize-Slack-For-Conversation Unit Tests', () => {
     expectedResult.raw_input_data.slack = menuMessageParams.slack;
 
     func = actionNormSlackForConversation.main;
-    const mockCloudFunctions = nock(cloudFunctionsUrl)
-      .get(`/${namespace}/packages/${packageName}`)
-      .reply(200, expectedCloudFunctions);
-
-    const mockCloudantGet = nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(() => {
-        return true;
-      })
-      .reply(200, auth);
 
     return func(menuMessageParams).then(
       result => {
-        if (!mockCloudantGet.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!mockCloudFunctions.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock Cloud Functions Get server did not get called.');
-        }
         assert.deepEqual(result, expectedResult);
       },
       error => {
@@ -262,27 +196,9 @@ describe('Starter Code Normalize-Slack-For-Conversation Unit Tests', () => {
     expectedResult.raw_input_data.slack = textMessageParams.slack;
 
     func = actionNormSlackForConversation.main;
-    const mockCloudFunctions = nock(cloudFunctionsUrl)
-      .get(`/${namespace}/packages/${packageName}`)
-      .reply(200, expectedCloudFunctions);
-
-    const mockCloudantGet = nock(cloudantUrl)
-      .get(`/${cloudantAuthDbName}/${cloudantAuthKey}`)
-      .query(() => {
-        return true;
-      })
-      .reply(200, auth);
 
     return func(textMessageParams).then(
       result => {
-        if (!mockCloudantGet.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock Cloudant Get server did not get called.');
-        }
-        if (!mockCloudFunctions.isDone()) {
-          nock.cleanAll();
-          assert(false, 'Mock Cloud Functions Get server did not get called.');
-        }
         assert.deepEqual(result, expectedResult);
       },
       error => {


### PR DESCRIPTION
Improved overall pipeline execution time by reducing the number of Cloudant db calls.
The user auth is loaded _once_ at the start of the pipeline (in channel/receive) action and then passed through the pipeline in the `raw_input_data.auth` field.
Subsequent pipeline actions which require auth do not have to make a GET request to Cloudant. They simply get it from the incoming params.
The last action in the pipeline (channel/post) strips out the `raw_input_data` field so the auth never leaks out.