### PR TITLE
MVP: Support for options.value as object

### DIFF
--- a/starter-code/normalize-for-channel/normalize-conversation-for-facebook.js
+++ b/starter-code/normalize-for-channel/normalize-conversation-for-facebook.js
@@ -118,6 +118,23 @@ function generateFacebookPayload(params) {
 }
 
 /**
+ * Function normalizes the provided option value to
+ * string format so Facebook accepts it.
+ * @param {string/JSON} value - option value (could be string/JSON obj)
+ * @return {string} - stringified option value
+ */
+function getNormalizedOptionsValue(value) {
+  let normalizedValue = value;
+  if (value instanceof Object) {
+    assert(value.input && value.input.text); // Input and text both must be present
+    assert(typeof value.input.text, 'string'); // Text must be string
+    normalizedValue = value.input.text; // Do this for MVP as a safeguard
+  }
+  assert.equal(typeof normalizedValue, 'string'); // Default case (for MVP)
+  return normalizedValue;
+}
+
+/**
  * Function generates a message containing image as attachment
  * as per Facebook guidelines from the generic element returned
  * from Conversation.
@@ -147,7 +164,7 @@ function generateFbQuickReplyMessage(element) {
     const updatedOptionObj = {};
     updatedOptionObj.content_type = 'text';
     updatedOptionObj.title = optionObj.label; // Required
-    updatedOptionObj.payload = optionObj.value; // Required
+    updatedOptionObj.payload = getNormalizedOptionsValue(optionObj.value); // Required
     return updatedOptionObj;
   });
   return {
@@ -170,7 +187,7 @@ function generateFbTemplateMessage(element) {
     const updatedOptionObj = {};
     updatedOptionObj.type = 'postback';
     updatedOptionObj.title = optionObj.label; // Required
-    updatedOptionObj.payload = optionObj.value; // Required
+    updatedOptionObj.payload = getNormalizedOptionsValue(optionObj.value); // Required
     return updatedOptionObj;
   });
   // Use generic template and split options into groups of three

--- a/starter-code/normalize-for-channel/normalize-conversation-for-slack.js
+++ b/starter-code/normalize-for-channel/normalize-conversation-for-slack.js
@@ -137,6 +137,23 @@ function insertConversationOutput(params, output) {
 }
 
 /**
+ * Function normalizes the provided option value to
+ * string format so Facebook accepts it.
+ * @param {string/JSON} value - option value (could be string/JSON obj)
+ * @return {string} - stringified option value
+ */
+function getNormalizedOptionsValue(value) {
+  let normalizedValue = value;
+  if (value instanceof Object) {
+    assert(value.input && value.input.text); // Input and text both must be present
+    assert(typeof value.input.text, 'string'); // Text must be string
+    normalizedValue = value.input.text; // Do this for MVP as a safeguard
+  }
+  assert.equal(typeof normalizedValue, 'string'); // Default case (for MVP)
+  return normalizedValue;
+}
+
+/**
  * Generates the image attachment data as per Slack specs.
  *
  * @param  {JSON} params - The generic element object
@@ -168,7 +185,7 @@ function generateSlackOptionsData(element) {
     updatedOptionObj.name = optionObj.label;
     updatedOptionObj.type = 'button';
     updatedOptionObj.text = optionObj.label;
-    updatedOptionObj.value = optionObj.value;
+    updatedOptionObj.value = getNormalizedOptionsValue(optionObj.value);
     return updatedOptionObj;
   });
 

--- a/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-facebook.js
+++ b/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-facebook.js
@@ -590,6 +590,52 @@ describe('Starter-Code Normalize-For-Facebook Unit Tests', () => {
     );
   });
 
+  it('validate normalization works for generic response_type - option (options.value is JSON object)', () => {
+    delete textMsgParams.conversation.output.text;
+    delete textMsgParams.conversation.output.facebook;
+
+    delete textRes.raw_output_data.conversation.output.text;
+    delete textRes.raw_output_data.conversation.output.facebook;
+    delete textRes.text;
+
+    // Make the first option value an object instead of a string.
+    genericFromConversation[2].options[0].value = {
+      input: {
+        text: 'Location 1'
+      },
+      intents: [
+        {
+          intent: 'get-location',
+          confidence: 0.8177993774414063
+        }
+      ],
+      entities: [
+        {
+          entity: 'Location',
+          location: [0, 9],
+          value: '1',
+          confidence: 1
+        }
+      ]
+    };
+
+    // Add a generic option response from Conversation
+    textMsgParams.conversation.output.generic = genericFromConversation[2];
+
+    textRes.raw_output_data.conversation.output.generic = textMsgParams.conversation.output.generic;
+    delete textRes.message;
+    textRes.message = [genericForFacebook[2]];
+
+    return actionNormForFacebook(textMsgParams).then(
+      result => {
+        assert.deepEqual(result, textRes);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
   it('validate error when no conversation data', () => {
     delete textMsgParams.conversation.output;
 

--- a/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-slack.js
+++ b/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-slack.js
@@ -340,6 +340,48 @@ describe('Starter-Code Normalize-For-Slack Unit Tests', () => {
     );
   });
 
+  it('validate normalization works for generic response_type - option (options.value is JSON object)', () => {
+    delete params.conversation.output.text;
+    delete expectedResult.raw_output_data.conversation.output.text;
+    delete expectedResult.text;
+
+    // Make the first option value an object instead of a string.
+    genericFromConversation[2].options[0].value = {
+      input: {
+        text: 'Location 1'
+      },
+      intents: [
+        {
+          intent: 'get-location',
+          confidence: 0.8177993774414063
+        }
+      ],
+      entities: [
+        {
+          entity: 'Location',
+          location: [0, 9],
+          value: '1',
+          confidence: 1
+        }
+      ]
+    };
+
+    // Add a generic option response from Conversation
+    params.conversation.output.generic = genericFromConversation[2];
+
+    expectedResult.raw_output_data.conversation.output.generic = params.conversation.output.generic;
+    expectedResult = Object.assign(expectedResult, genericForSlack[2]);
+
+    return actionNormForSlack(params).then(
+      result => {
+        assert.deepEqual(result, expectedResult);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
   it('validate normalization works for multiple generic response_type list', () => {
     delete params.conversation.output.text;
     delete expectedResult.raw_output_data.conversation.output.text;


### PR DESCRIPTION
We want to allow `options[i].value` to be an object with `input.text` attribute. The structure of the options list in generic will then be:

```json
{
  "generic": [
    {
      "response_type": "option",
      "title": "Select a location",
      "options": [
        {
          "label": "Location 1",
          "value": {
            "input": {
              "text": "Value1"
            }
          }
        },
        {
          "label": "Location 2",
          "value": {
            "input": {
              "text": "Value2"
            }
          }
        },
        {
          "label": "Location 3",
          "value": {
            "input": {
              "text": "Value3"
            }
          }
        }
      ]
    }
  ]
}
```