### PR TITLE
Support for pause response type

### DIFF
--- a/channels/facebook/post/index.js
+++ b/channels/facebook/post/index.js
@@ -130,8 +130,12 @@ function extractFacebookParams(params) {
 function validateParameters(params) {
   // Required: Channel identifier
   assert(params.recipient && params.recipient.id, 'Recepient id not provided.');
-  // Required: Message to send
-  assert(params.message, 'Message object not provided.');
+
+  // Required: Message object or sender_action
+  assert(
+    params.message || params.sender_action,
+    'Must provide message object or sender_action.'
+  );
 
   // Required: raw_input_data and Facebook Auth
   assert(

--- a/channels/slack/multiple_post/index.js
+++ b/channels/slack/multiple_post/index.js
@@ -75,14 +75,39 @@ function postMultipleMessages(params) {
 function postMessage(sequenceName, params, responses, size, index, ow) {
   if (index < size) {
     const paramsForInvocation = Object.assign({}, params);
+    let sleepDuration = params.message && params.message.time;
 
     // If we have an array of messages, extract the next element we haven't sent and store
     // it at the root of the JSON
     if (Array.isArray(params.message)) {
+      sleepDuration = params.message[index].time;
       Object.assign(paramsForInvocation, params.message[index]);
       delete paramsForInvocation.message;
     }
-
+    // Check if this is a pause response.
+    if (
+      paramsForInvocation.response_type &&
+      paramsForInvocation.response_type === 'pause'
+    ) {
+      // There's no way to send user-typing indicator in Slack!
+      // Just sleep for specified duration and invoke the action
+      // with the next set of parameters.
+      return sleep(sleepDuration)
+        .then(() => {
+          return postMessage(
+            sequenceName,
+            params,
+            responses,
+            size,
+            index + 1,
+            ow
+          );
+        })
+        .catch(e => {
+          // Capture the response, don't send any further messages
+          responses.failedPosts.push(e);
+        });
+    }
     return invokeAction(sequenceName, paramsForInvocation, ow)
       .then(result => {
         responses.successfulPosts.push(result);
@@ -100,7 +125,26 @@ function postMessage(sequenceName, params, responses, size, index, ow) {
         responses.failedPosts.push(e);
       });
   }
-  return responses;
+  // index=size. We're done. Resolve.
+  return new Promise(resolve => {
+    resolve(responses);
+  });
+}
+
+/**
+ * Sleep for a supplied amount of milliseconds.
+ *
+ * @param  {integer} ms - number of milliseconds to sleep
+ * @return {Promise}    - Promise resolve
+ */
+function sleep(ms) {
+  return new Promise(resolve => {
+    if (ms) {
+      setTimeout(resolve, ms);
+    } else {
+      resolve();
+    }
+  });
 }
 
 /**

--- a/starter-code/normalize-for-channel/normalize-conversation-for-facebook.js
+++ b/starter-code/normalize-for-channel/normalize-conversation-for-facebook.js
@@ -108,10 +108,18 @@ function generateFacebookPayload(params) {
           facebookMessage = generateFbTemplateMessage(element);
         }
         break;
-      default:
+      case 'pause':
+        facebookMessage = generateFbPauseMessage(element);
+        break;
+      case 'text':
         facebookMessage = generateFbTextMessage(element);
+        break;
+      default:
+        facebookMessage = undefined;
     }
-    facebookMessageList.push(facebookMessage);
+    if (facebookMessage) {
+      facebookMessageList.push(facebookMessage);
+    }
     return element;
   });
   return facebookMessageList;
@@ -214,6 +222,22 @@ function generateFbTemplateMessage(element) {
       }
     }
   };
+}
+
+/**
+ * Function generates a user_typing event message as per Facebook guidelines
+ * from the generic pause element returned from Conversation.
+ * @param {JSON} element - JSON object containing pause
+ * @return {JSON} - Facebook message containing sender_typing
+ */
+function generateFbPauseMessage(element) {
+  const message = {
+    time: element.time
+  };
+  if (element.typing) {
+    message.sender_action = 'typing_on';
+  }
+  return message;
 }
 
 /**

--- a/starter-code/normalize-for-channel/normalize-conversation-for-slack.js
+++ b/starter-code/normalize-for-channel/normalize-conversation-for-slack.js
@@ -114,8 +114,14 @@ function insertConversationOutput(params, output) {
         case 'option':
           slackOutput.message.push(generateSlackOptionsData(element));
           break;
-        default:
+        case 'pause':
+          slackOutput.message.push(generateSlackPauseMessage(element));
+          break;
+        case 'text':
           slackOutput.message.push({ text: element.text });
+          break;
+        default:
+          break;
       }
       return element;
     });
@@ -198,6 +204,17 @@ function generateSlackOptionsData(element) {
       }
     ]
   };
+}
+
+/**
+ * Boilerplate function which should eventually translate
+ * pause response type to Slack-acceptable sender-typing event
+ * from the generic pause element returned from Conversation.
+ * @param {JSON} element - JSON object containing pause
+ * @return {JSON} - Slack message containing sender_typing
+ */
+function generateSlackPauseMessage(element) {
+  return element;
 }
 
 /**

--- a/test/integration/channels/slack/breakdown.sh
+++ b/test/integration/channels/slack/breakdown.sh
@@ -54,3 +54,20 @@ ${WSK} action delete ${PIPELINE_SEND_ATTACHED_RESPONSE}_slack/multiple_post > /d
 ${WSK} action delete ${PIPELINE_SEND_ATTACHED_RESPONSE}_slack/receive > /dev/null
 
 ${WSK} package delete ${PIPELINE_SEND_ATTACHED_RESPONSE}_slack > /dev/null
+
+
+# Request and receive an interactive message requiring multipost
+PIPELINE_SEND_ATTACHED_MULTIPOST="$1-integration-slack-send-attached-multipost"
+
+CLOUDANT_AUTH_KEY="${PIPELINE_SEND_ATTACHED_MULTIPOST}"
+
+curl -s -XDELETE ${__TEST_CLOUDANT_URL}/authdb/${CLOUDANT_AUTH_KEY}?rev=$(curl -s ${__TEST_CLOUDANT_URL}/authdb/${CLOUDANT_AUTH_KEY} | jq -r ._rev) > /dev/null
+
+${WSK} action delete ${PIPELINE_SEND_ATTACHED_MULTIPOST}_slack/send-attached-message-multipost > /dev/null
+${WSK} action delete ${PIPELINE_SEND_ATTACHED_MULTIPOST}_slack/post > /dev/null
+${WSK} action delete ${PIPELINE_SEND_ATTACHED_MULTIPOST}_slack/multiple_post > /dev/null
+${WSK} action delete ${PIPELINE_SEND_ATTACHED_MULTIPOST}_slack/receive > /dev/null
+${WSK} action delete ${PIPELINE_SEND_ATTACHED_MULTIPOST}_postsequence > /dev/null
+${WSK} action delete ${PIPELINE_SEND_ATTACHED_MULTIPOST} > /dev/null
+
+${WSK} package delete ${PIPELINE_SEND_ATTACHED_MULTIPOST}_slack > /dev/null

--- a/test/integration/deploy/channels/slack/test.verify-slack.js
+++ b/test/integration/deploy/channels/slack/test.verify-slack.js
@@ -150,7 +150,9 @@ describe('deploy verify-slack integration tests', () => {
       .catch(error => {
         assert(false, error);
       });
-  }).retries(4);
+  })
+    .timeout(30000)
+    .retries(4);
 
   function createHmacKey(clientId, clientSecret) {
     const hmacKey = `${clientId}&${clientSecret}`;

--- a/test/integration/starter-code/mock-conversation-generic-data.js
+++ b/test/integration/starter-code/mock-conversation-generic-data.js
@@ -32,6 +32,11 @@ function main(params) {
 
     const genericData = [
       {
+        response_type: 'pause',
+        time: 1000,
+        typing: true
+      },
+      {
         response_type: 'text',
         text: 'Output text from mock-conversation.'
       },

--- a/test/integration/starter-code/test.starter-code.facebook.js
+++ b/test/integration/starter-code/test.starter-code.facebook.js
@@ -120,6 +120,11 @@ describe('starter-code integration tests for facebook', () => {
 
     genericData = [
       {
+        response_type: 'pause',
+        time: 1000,
+        typing: true
+      },
+      {
         response_type: 'text',
         text: outputText
       },
@@ -151,19 +156,23 @@ describe('starter-code integration tests for facebook', () => {
 
     facebookMultiModalData = [
       {
+        sender_action: 'typing_on',
+        time: 1000
+      },
+      {
         text: outputText
       },
       {
         attachment: {
           type: 'image',
           payload: {
-            url: genericData[1].source
+            url: genericData[2].source
           }
         }
       },
       {
-        text: genericData[2].title,
-        quick_replies: genericData[2].options.map(e => {
+        text: genericData[3].title,
+        quick_replies: genericData[3].options.map(e => {
           const el = {};
           el.content_type = 'text';
           el.title = e.label;

--- a/test/integration/starter-code/test.starter-code.slack.js
+++ b/test/integration/starter-code/test.starter-code.slack.js
@@ -150,6 +150,11 @@ describe('starter-code integration tests for slack', () => {
 
     genericData = [
       {
+        response_type: 'pause',
+        time: 1000,
+        typing: true
+      },
+      {
         response_type: 'text',
         text: outputText
       },
@@ -181,22 +186,27 @@ describe('starter-code integration tests for slack', () => {
 
     slackMultiModalData = {
       message: [
+        {
+          response_type: 'pause',
+          time: 1000,
+          typing: true
+        },
         { text: outputText },
         {
           attachments: [
             {
-              image_url: genericData[1].source,
-              pretext: genericData[1].description,
-              title: genericData[1].title
+              image_url: genericData[2].source,
+              pretext: genericData[2].description,
+              title: genericData[2].title
             }
           ]
         },
         {
           attachments: [
             {
-              text: genericData[2].title,
-              callback_id: genericData[2].title,
-              actions: genericData[2].options.map(e => {
+              text: genericData[3].title,
+              callback_id: genericData[3].title,
+              actions: genericData[3].options.map(e => {
                 const el = {};
                 el.name = e.label;
                 el.type = 'button';

--- a/test/unit/channels/facebook/test.channel.facebook.multiple_post.js
+++ b/test/unit/channels/facebook/test.channel.facebook.multiple_post.js
@@ -22,7 +22,7 @@ const sinon = require('sinon');
 
 const previousTestName = process.env.__OW_ACTION_NAME;
 
-describe('Multi-post Unit Tests', () => {
+describe('Facebook Multi-post Unit Tests', () => {
   const apiHost = 'xxx';
   const apiKey = 'xxx';
   const namespace = 'xxx';
@@ -239,12 +239,112 @@ describe('Multi-post Unit Tests', () => {
     );
   });
 
+  it('validate multipost with empty message array', () => {
+    const multiPostParams = {
+      recipient: {
+        id: 'xxx'
+      },
+      message: [],
+      raw_input_data: {
+        conversation: {
+          input: {
+            text: 'Show me an image'
+          },
+          context: {}
+        },
+        provider: 'facebook',
+        auth: {
+          conversation: {
+            username: 'xxx',
+            password: 'xxx',
+            workspace_id: 'xxx'
+          },
+          _revs_info: [
+            {
+              rev: '1-a11033fca1d3ccd1fad5c0b2ba5de0d3',
+              status: 'available'
+            }
+          ],
+          _id: '8bcca000-fbc2-11e7-8a63-0d454d7bbecd',
+          facebook: {
+            app_secret: 'xxx',
+            page_access_token: 'xxx',
+            verification_token: 'xxx'
+          },
+          _rev: '1-a11033fca1d3ccd1fad5c0b2ba5de0d3'
+        },
+        facebook: {
+          sender: {
+            id: 'xxx'
+          },
+          recipient: {
+            id: 'xxx'
+          },
+          timestamp: 1516220585636,
+          message: {
+            mid: 'mid.$cAAdxoMih2R1nNw9epFhBcocloKpX',
+            seq: 1084,
+            text: 'Show me an image'
+          }
+        },
+        cloudant_context_key: 'xxx'
+      },
+      raw_output_data: {
+        conversation: {
+          entities: [],
+          context: {},
+          intents: [
+            {
+              intent: 'multimodal',
+              confidence: 1
+            }
+          ],
+          output: {
+            text: [],
+            nodes_visited: ['node_1_1514502764444'],
+            generic: [
+              {
+                response_type: 'connect_to_agent',
+                message_to_human_agent: 'Customer needs to know their PUK.',
+                topic: 'Find PUK'
+              }
+            ],
+            log_messages: []
+          },
+          input: {
+            text: 'Show me an image'
+          }
+        }
+      }
+    };
+
+    const multiPostResponse = {
+      postResponses: {
+        successfulPosts: [],
+        failedPosts: []
+      }
+    };
+
+    return mockMultiplePost.main(multiPostParams).then(
+      result => {
+        assert.deepEqual(result, multiPostResponse);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
   it('validate multipost with arrayed message', () => {
     const multiPostParams = {
       recipient: {
         id: 'xxx'
       },
       message: [
+        {
+          sender_action: 'typing_on',
+          time: 3000
+        },
         {
           text: 'Here is your multi-modal response.'
         },
@@ -255,6 +355,9 @@ describe('Multi-post Unit Tests', () => {
               url: 'https://xxx.com/xxx.png'
             }
           }
+        },
+        {
+          time: 3000
         },
         {
           text: 'Choose your location',
@@ -384,6 +487,11 @@ describe('Multi-post Unit Tests', () => {
             nodes_visited: ['node_1_1514502764444'],
             generic: [
               {
+                time: 3000,
+                typing: true,
+                response_type: 'pause'
+              },
+              {
                 text: 'Here is your multi-modal response.',
                 response_type: 'text'
               },
@@ -392,6 +500,11 @@ describe('Multi-post Unit Tests', () => {
                 source: 'https://xxx.com/xxx.png',
                 description: 'Image description',
                 response_type: 'image'
+              },
+              {
+                time: 2000,
+                typing: false,
+                response_type: 'pause'
               },
               {
                 title: 'Choose your location',
@@ -425,6 +538,40 @@ describe('Multi-post Unit Tests', () => {
       duration: 290,
       name: 'psequence_postsequence',
       subject: 'xxx',
+      activationId: '3812cc2341964f6992cc234196cf69bf',
+      publish: false,
+      annotations: [
+        { key: 'topmost', value: true },
+        { key: 'path', value: 'xxx_xxx/psequence_postsequence' },
+        { key: 'kind', value: 'sequence' },
+        { key: 'limits', value: { timeout: 60000, memory: 256, logs: 10 } }
+      ],
+      version: '0.0.1',
+      response: {
+        result: {
+          text: 200,
+          params: {
+            recipient: { id: 'xxx' },
+            sender_action: 'typing_on'
+          },
+          url: 'https://graph.facebook.com/v2.6/me/messages'
+        },
+        success: true,
+        status: 'success'
+      },
+      end: 1516220587532,
+      logs: [
+        '4b77186c543346e3b7186c543386e3cc',
+        '441e31363e9141c09e31363e91e1c04f'
+      ],
+      start: 1516220587157,
+      namespace: 'xxx_xxx'
+    };
+
+    const postResponse2 = {
+      duration: 290,
+      name: 'psequence_postsequence',
+      subject: 'xxx',
       activationId: '4812cc2341964f6992cc234196cf69bf',
       publish: false,
       annotations: [
@@ -455,7 +602,7 @@ describe('Multi-post Unit Tests', () => {
       namespace: 'xxx_xxx'
     };
 
-    const postResponse2 = {
+    const postResponse3 = {
       duration: 775,
       name: 'psequence_postsequence',
       subject: 'xxx',
@@ -494,7 +641,7 @@ describe('Multi-post Unit Tests', () => {
       namespace: 'xxx_xxx'
     };
 
-    const postResponse3 = {
+    const postResponse4 = {
       duration: 570,
       name: 'psequence_postsequence',
       subject: 'xxx',
@@ -544,6 +691,19 @@ describe('Multi-post Unit Tests', () => {
     const multiPostResponse = {
       postResponses: {
         successfulPosts: [
+          {
+            successResponse: {
+              text: 200,
+              params: {
+                recipient: {
+                  id: 'xxx'
+                },
+                sender_action: 'typing_on'
+              },
+              url: 'https://graph.facebook.com/v2.6/me/messages'
+            },
+            activationId: '3812cc2341964f6992cc234196cf69bf'
+          },
           {
             successResponse: {
               text: 200,
@@ -628,7 +788,9 @@ describe('Multi-post Unit Tests', () => {
       .post(mockCloudFunctionsEndpoints.actionsEndpoint)
       .reply(200, postResponse2)
       .post(mockCloudFunctionsEndpoints.actionsEndpoint)
-      .reply(200, postResponse3);
+      .reply(200, postResponse3)
+      .post(mockCloudFunctionsEndpoints.actionsEndpoint)
+      .reply(200, postResponse4);
 
     return mockMultiplePost.main(multiPostParams).then(
       result => {
@@ -642,7 +804,7 @@ describe('Multi-post Unit Tests', () => {
         assert(false, error);
       }
     );
-  });
+  }).timeout(7000);
 
   it('validate multipost simple failure case', () => {
     const failedPost = {
@@ -802,7 +964,7 @@ describe('Multi-post Unit Tests', () => {
           {
             failureResponse: {
               name: 'OpenWhiskError',
-              message: 'POST https://xxx/api/v1/namespaces/xxx/actions/deployname_postsequence?blocking=true Returned HTTP 400 (Bad Request) --> "Action returned with status code 400, message: Bad Request"',
+              message: 'POST https://xxx/api/v1/namespaces/xxx/actions/deployname_postsequence Returned HTTP 400 (Bad Request) --> "Action returned with status code 400, message: Bad Request"',
               error: {
                 duration: 648,
                 name: 'psequence_postsequence',

--- a/test/unit/channels/facebook/test.channel.facebook.multiple_post.js
+++ b/test/unit/channels/facebook/test.channel.facebook.multiple_post.js
@@ -964,7 +964,7 @@ describe('Facebook Multi-post Unit Tests', () => {
           {
             failureResponse: {
               name: 'OpenWhiskError',
-              message: 'POST https://xxx/api/v1/namespaces/xxx/actions/deployname_postsequence Returned HTTP 400 (Bad Request) --> "Action returned with status code 400, message: Bad Request"',
+              message: 'POST https://xxx/api/v1/namespaces/xxx/actions/deployname_postsequence?blocking=true Returned HTTP 400 (Bad Request) --> "Action returned with status code 400, message: Bad Request"',
               error: {
                 duration: 648,
                 name: 'psequence_postsequence',

--- a/test/unit/channels/facebook/test.channel.facebook.post.js
+++ b/test/unit/channels/facebook/test.channel.facebook.post.js
@@ -37,7 +37,7 @@ const errorBadUri = `Invalid URI "${badUri}"`;
 const errorMovedPermanently = 'Action returned with status code 301, message: Moved Permanently';
 const errorNoPageAccessToken = 'auth.facebook.page_access_token not found.';
 const errorNoRecipientId = 'Recepient id not provided.';
-const errorNoMessageText = 'Message object not provided.';
+const errorNoMessageText = 'Must provide message object or sender_action.';
 
 describe('Facebook Post Unit Tests', () => {
   let postParams = {};
@@ -132,7 +132,6 @@ describe('Facebook Post Unit Tests', () => {
         assert(false, result);
       },
       error => {
-        assert.equal(error.name, 'AssertionError');
         assert.equal(error.message, errorNoPageAccessToken);
       }
     );
@@ -152,7 +151,7 @@ describe('Facebook Post Unit Tests', () => {
     );
   });
 
-  it('validate error when no message text provided', () => {
+  it('validate error when no message text or sender_action provided', () => {
     delete postParams.message;
     func = facebookPost.main;
     return func(postParams).then(

--- a/test/unit/channels/slack/test.channel.slack.multiple_post.js
+++ b/test/unit/channels/slack/test.channel.slack.multiple_post.js
@@ -951,7 +951,7 @@ describe('Slack Multi-post Unit Tests', () => {
           {
             failureResponse: {
               name: 'OpenWhiskError',
-              message: 'POST https://xxx/api/v1/namespaces/xxx/actions/deployname_postsequence Returned HTTP 400 (Bad Request) --> "Action returned with status code 400, message: Bad Request"',
+              message: 'POST https://xxx/api/v1/namespaces/xxx/actions/deployname_postsequence?blocking=true Returned HTTP 400 (Bad Request) --> "Action returned with status code 400, message: Bad Request"',
               error: {
                 duration: 648,
                 name: 'post',

--- a/test/unit/channels/slack/test.channel.slack.multiple_post.js
+++ b/test/unit/channels/slack/test.channel.slack.multiple_post.js
@@ -22,7 +22,7 @@ const sinon = require('sinon');
 
 const previousTestName = process.env.__OW_ACTION_NAME;
 
-describe('Multiple_post Slack Unit Tests', () => {
+describe('Slack Multi-post Unit Tests', () => {
   const apiHost = 'xxx';
   const apiKey = 'xxx';
   const namespace = 'xxx';
@@ -239,6 +239,148 @@ describe('Multiple_post Slack Unit Tests', () => {
     );
   });
 
+  it('validate multipost with empty message array', () => {
+    const multiPostParams = {
+      raw_input_data: {
+        conversation: {
+          input: {
+            text: 'show me a multimedia response'
+          },
+          context: {
+            conversation_id: 'fcc88abe-fd43-4361-adee-394f639d6d94',
+            system: {
+              branch_exited_reason: 'completed',
+              dialog_request_counter: 6,
+              branch_exited: true,
+              dialog_turn_counter: 6,
+              dialog_stack: [
+                {
+                  dialog_node: 'root'
+                }
+              ],
+              _node_output_map: {
+                node_18_1484802647885: [0]
+              }
+            }
+          }
+        },
+        provider: 'slack',
+        auth: {
+          conversation: {
+            username: 'xxx',
+            password: 'xxx',
+            workspace_id: 'xxx'
+          },
+          _revs_info: [
+            {
+              rev: '2-e2a470f05b05c43208870457ad0f8db8',
+              status: 'available'
+            },
+            {
+              rev: '1-d792e5a468d5d351231dcb0968a36a56',
+              status: 'available'
+            }
+          ],
+          _id: '23a563c0-05d3-11e8-94cf-73584df37eea',
+          slack: {
+            client_id: 'xxx',
+            client_secret: 'xxx',
+            verification_token: 'xxx',
+            bot_users: {
+              xxx: {
+                access_token: 'xxx',
+                bot_access_token: 'xxx'
+              }
+            }
+          },
+          _rev: '2-e2a470f05b05c43208870457ad0f8db8'
+        },
+        bot_id: 'xxx',
+        slack: {
+          team_id: 'xxx',
+          event: {
+            channel: 'xxx',
+            ts: '1517348453.000747',
+            text: 'show me a multimedia response',
+            event_ts: '1517348453.000747',
+            type: 'message',
+            user: 'xxx'
+          },
+          api_app_id: 'xxx',
+          authed_users: ['xxx'],
+          event_time: 1517348453,
+          token: 'xxx',
+          type: 'event_callback',
+          event_id: 'Ev916HGH8S'
+        },
+        cloudant_context_key: 'xxx'
+      },
+      channel: 'xxx',
+      url: 'https://slack.com/api/chat.postMessage',
+      ts: '1517348453.000747',
+      message: [],
+      raw_output_data: {
+        conversation: {
+          entities: [],
+          context: {
+            conversation_id: 'fcc88abe-fd43-4361-adee-394f639d6d94',
+            system: {
+              branch_exited_reason: 'completed',
+              dialog_request_counter: 7,
+              branch_exited: true,
+              dialog_turn_counter: 7,
+              dialog_stack: [
+                {
+                  dialog_node: 'root'
+                }
+              ],
+              _node_output_map: {
+                node_18_1484802647885: [0]
+              }
+            }
+          },
+          intents: [
+            {
+              intent: 'multimodal',
+              confidence: 0.8660579204559327
+            }
+          ],
+          output: {
+            text: [],
+            nodes_visited: ['node_1_1514502764444'],
+            generic: [
+              {
+                response_type: 'connect_to_agent',
+                message_to_human_agent: 'Customer needs to know their PUK.',
+                topic: 'Find PUK'
+              }
+            ],
+            log_messages: []
+          },
+          input: {
+            text: 'show me a multimedia response'
+          }
+        }
+      }
+    };
+
+    const multiPostResponse = {
+      postResponses: {
+        successfulPosts: [],
+        failedPosts: []
+      }
+    };
+
+    return mockMultiplePost.main(multiPostParams).then(
+      result => {
+        assert.deepEqual(result, multiPostResponse);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
   it('validate multipost with arrayed message', () => {
     const multiPostParams = {
       raw_input_data: {
@@ -320,6 +462,11 @@ describe('Multiple_post Slack Unit Tests', () => {
       ts: '1517348453.000747',
       message: [
         {
+          response_type: 'pause',
+          time: 3000,
+          typing: true
+        },
+        {
           text: 'Here is your multi-modal response.'
         },
         {
@@ -330,6 +477,10 @@ describe('Multiple_post Slack Unit Tests', () => {
               image_url: 'https://s.w-x.co/240x180_twc_default.png'
             }
           ]
+        },
+        {
+          response_type: 'pause',
+          time: 3000
         },
         {
           attachments: [
@@ -391,6 +542,11 @@ describe('Multiple_post Slack Unit Tests', () => {
             nodes_visited: ['node_1_1514502764444'],
             generic: [
               {
+                response_type: 'pause',
+                time: 3000,
+                typing: true
+              },
+              {
                 text: 'Here is your multi-modal response.',
                 response_type: 'text'
               },
@@ -399,6 +555,10 @@ describe('Multiple_post Slack Unit Tests', () => {
                 source: 'https://s.w-x.co/240x180_twc_default.png',
                 description: 'Image description',
                 response_type: 'image'
+              },
+              {
+                response_type: 'pause',
+                time: 3000
               },
               {
                 title: 'Choose your location',
@@ -641,7 +801,7 @@ describe('Multiple_post Slack Unit Tests', () => {
         assert(false, error);
       }
     );
-  });
+  }).timeout(7000);
 
   it('validate multipost simple failure case', () => {
     const failedPost = {
@@ -791,7 +951,7 @@ describe('Multiple_post Slack Unit Tests', () => {
           {
             failureResponse: {
               name: 'OpenWhiskError',
-              message: 'POST https://xxx/api/v1/namespaces/xxx/actions/deployname_postsequence?blocking=true Returned HTTP 400 (Bad Request) --> "Action returned with status code 400, message: Bad Request"',
+              message: 'POST https://xxx/api/v1/namespaces/xxx/actions/deployname_postsequence Returned HTTP 400 (Bad Request) --> "Action returned with status code 400, message: Bad Request"',
               error: {
                 duration: 648,
                 name: 'post',

--- a/test/unit/channels/slack/test.channel.slack.post.js
+++ b/test/unit/channels/slack/test.channel.slack.post.js
@@ -150,7 +150,6 @@ describe('Slack Post Unit Tests', () => {
     try {
       func(options);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorNoChannel);
     }
   });
@@ -163,7 +162,6 @@ describe('Slack Post Unit Tests', () => {
     try {
       func(options);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorNoText);
     }
   });

--- a/test/unit/channels/slack/test.channel.slack.receive.js
+++ b/test/unit/channels/slack/test.channel.slack.receive.js
@@ -262,7 +262,6 @@ describe('Slack Receive Unit Tests', () => {
     try {
       func(messageParams);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorNoVerificationToken);
     }
   });
@@ -290,7 +289,6 @@ describe('Slack Receive Unit Tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       },
       error => {
-        assert.equal(error.error.name, 'AssertionError');
         assert.equal(error.error.message, errorBadVerificationToken);
       }
     );

--- a/test/unit/context/test.load-context.js
+++ b/test/unit/context/test.load-context.js
@@ -50,7 +50,6 @@ describe('Load Context Unit Tests: validateParams()', () => {
     try {
       func(params);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorNoRawInputData);
     }
   });
@@ -63,7 +62,6 @@ describe('Load Context Unit Tests: validateParams()', () => {
     try {
       func(params);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorNoCloudantContextKey);
     }
   });
@@ -76,7 +74,6 @@ describe('Load Context Unit Tests: validateParams()', () => {
     try {
       func(params);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorNoConversationObj);
     }
   });

--- a/test/unit/context/test.save-context.js
+++ b/test/unit/context/test.save-context.js
@@ -480,7 +480,6 @@ describe('Save Context Unit Tests: validateParams()', () => {
     try {
       func({});
     } catch (e) {
-      assert.equal(e.name, 'AssertionError');
       assert.equal(e.message, errorNoRawInputData);
     }
   });
@@ -489,7 +488,6 @@ describe('Save Context Unit Tests: validateParams()', () => {
     try {
       func({ raw_input_data: {} });
     } catch (e) {
-      assert.equal(e.name, 'AssertionError');
       assert.equal(e.message, errorNoCloudantContextKey);
     }
   });
@@ -500,7 +498,6 @@ describe('Save Context Unit Tests: validateParams()', () => {
         raw_input_data: { cloudant_context_key: 'xyz' }
       });
     } catch (e) {
-      assert.equal(e.name, 'AssertionError');
       assert.equal(e.message, errorNoConversationObj);
     }
   });

--- a/test/unit/conversation/test.conversation.js
+++ b/test/unit/conversation/test.conversation.js
@@ -159,7 +159,6 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(error => {
-        assert.equal(error.name, 'AssertionError');
         assert.equal(error.message, errorNoConversationInput);
       });
   });
@@ -173,7 +172,6 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(error => {
-        assert.equal(error.name, 'AssertionError');
         assert.equal(error.message, errorNoProvider);
       });
   });
@@ -235,7 +233,6 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(e => {
-        assert.equal('AssertionError', e.name);
         assert.equal(errorNoConversationObjInAuth, e.message);
       });
   });
@@ -252,7 +249,6 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(e => {
-        assert.equal('AssertionError', e.name);
         assert.equal(errorNoConversationUsernameInAuth, e.message);
       });
   });
@@ -269,7 +265,6 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(e => {
-        assert.equal('AssertionError', e.name);
         assert.equal(errorNoConversationPassInAuth, e.message);
       });
   });
@@ -286,7 +281,6 @@ describe('conversation unit tests', () => {
         assert(false, 'Action succeeded unexpectedly.');
       })
       .catch(e => {
-        assert.equal('AssertionError', e.name);
         assert.equal(errorNoConversationWorkspaceIdInAuth, e.message);
       });
   });

--- a/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-facebook.js
+++ b/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-facebook.js
@@ -163,6 +163,11 @@ describe('Starter-Code Normalize-For-Facebook Unit Tests', () => {
           value: 'Location 12'
         }
       ]
+    },
+    {
+      time: '10000',
+      typing: true,
+      response_type: 'pause'
     }
   ];
 
@@ -277,6 +282,10 @@ describe('Starter-Code Normalize-For-Facebook Unit Tests', () => {
           ]
         }
       }
+    },
+    {
+      sender_action: 'typing_on',
+      time: genericFromConversation[4].time
     }
   ];
 
@@ -625,6 +634,87 @@ describe('Starter-Code Normalize-For-Facebook Unit Tests', () => {
     textRes.raw_output_data.conversation.output.generic = textMsgParams.conversation.output.generic;
     delete textRes.message;
     textRes.message = [genericForFacebook[2]];
+
+    return actionNormForFacebook(textMsgParams).then(
+      result => {
+        assert.deepEqual(result, textRes);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
+  it('validate normalization works for generic response_type - pause (typing TRUE)', () => {
+    delete textMsgParams.conversation.output.text;
+    delete textMsgParams.conversation.output.facebook;
+
+    delete textRes.raw_output_data.conversation.output.text;
+    delete textRes.raw_output_data.conversation.output.facebook;
+    delete textRes.text;
+
+    // Add a generic pause response from Conversation
+    textMsgParams.conversation.output.generic = genericFromConversation[4];
+
+    textRes.raw_output_data.conversation.output.generic = textMsgParams.conversation.output.generic;
+    delete textRes.message;
+    textRes.message = [genericForFacebook[4]];
+
+    return actionNormForFacebook(textMsgParams).then(
+      result => {
+        assert.deepEqual(result, textRes);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
+  it('validate normalization works for generic response_type - pause (typing FALSE)', () => {
+    delete textMsgParams.conversation.output.text;
+    delete textMsgParams.conversation.output.facebook;
+
+    delete textRes.raw_output_data.conversation.output.text;
+    delete textRes.raw_output_data.conversation.output.facebook;
+    delete textRes.text;
+
+    genericFromConversation[4].typing = false;
+    // Add a generic pause response from Conversation
+    textMsgParams.conversation.output.generic = genericFromConversation[4];
+
+    textRes.raw_output_data.conversation.output.generic = textMsgParams.conversation.output.generic;
+    delete textRes.message;
+    delete genericForFacebook[4].sender_action;
+    textRes.message = [genericForFacebook[4]];
+
+    return actionNormForFacebook(textMsgParams).then(
+      result => {
+        assert.deepEqual(result, textRes);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
+  it('validate no action taken for generic response_type- UNKNOWN', () => {
+    delete textMsgParams.conversation.output.text;
+    delete textMsgParams.conversation.output.facebook;
+
+    delete textRes.raw_output_data.conversation.output.text;
+    delete textRes.raw_output_data.conversation.output.facebook;
+    delete textRes.text;
+
+    // Add an unknown generic response from Conversation
+    textMsgParams.conversation.output.generic = [
+      {
+        response_type: 'connect_to_agent',
+        message_to_human_agent: 'Customer needs to know their PUK.',
+        topic: 'Find PUK'
+      }
+    ];
+    textRes.raw_output_data.conversation.output.generic = textMsgParams.conversation.output.generic;
+    textRes.message = []; // Facebook POST doesn't need to be invoked. Result list is empty.
 
     return actionNormForFacebook(textMsgParams).then(
       result => {

--- a/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-slack.js
+++ b/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-slack.js
@@ -154,6 +154,11 @@ describe('Starter-Code Normalize-For-Slack Unit Tests', () => {
             value: 'Location 3'
           }
         ]
+      },
+      {
+        time: '10000',
+        typing: true,
+        response_type: 'pause'
       }
     ];
 
@@ -195,6 +200,9 @@ describe('Starter-Code Normalize-For-Slack Unit Tests', () => {
         ]
       },
       {
+        message: [genericFromConversation[3]]
+      },
+      {
         message: [
           { text },
           {
@@ -221,7 +229,8 @@ describe('Starter-Code Normalize-For-Slack Unit Tests', () => {
                 })
               }
             ]
-          }
+          },
+          genericFromConversation[3]
         ]
       }
     ];
@@ -395,6 +404,55 @@ describe('Starter-Code Normalize-For-Slack Unit Tests', () => {
       expectedResult = Object.assign(expectedResult, e);
       return expectedResult;
     });
+    return actionNormForSlack(params).then(
+      result => {
+        assert.deepEqual(result, expectedResult);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
+  it('validate normalization works for generic response_type - pause', () => {
+    delete params.conversation.output.text;
+    delete expectedResult.raw_output_data.conversation.output.text;
+    delete expectedResult.text;
+
+    // Add a generic image response from Conversation
+    params.conversation.output.generic = genericFromConversation[3];
+
+    expectedResult.raw_output_data.conversation.output.generic = params.conversation.output.generic;
+    expectedResult = Object.assign(expectedResult, genericForSlack[3]);
+
+    return actionNormForSlack(params).then(
+      result => {
+        assert.deepEqual(result, expectedResult);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
+  it('validate no action taken for generic response_type- UNKNOWN', () => {
+    delete params.conversation.output.text;
+    delete expectedResult.raw_output_data.conversation.output.text;
+    delete expectedResult.text;
+
+    // Add an unknown generic response from Conversation
+    params.conversation.output.generic = [
+      {
+        response_type: 'connect_to_agent',
+        message_to_human_agent: 'Customer needs to know their PUK.',
+        topic: 'Find PUK'
+      }
+    ];
+    expectedResult.raw_output_data.conversation.output.generic = params.conversation.output.generic;
+    expectedResult.message = []; // Result list is empty.
+
+    expectedResult.raw_output_data.conversation.output.generic = params.conversation.output.generic;
+
     return actionNormForSlack(params).then(
       result => {
         assert.deepEqual(result, expectedResult);

--- a/test/unit/starter-code/normalize-for-conversation/test.starter-code.normalize-facebook-for-conversation.js
+++ b/test/unit/starter-code/normalize-for-conversation/test.starter-code.normalize-facebook-for-conversation.js
@@ -157,7 +157,6 @@ describe('Starter Code Normalize-Facebook-For-Conversation Unit Tests', () => {
     try {
       func(textMsgParams);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorBadSupplier);
     }
   });
@@ -169,7 +168,6 @@ describe('Starter Code Normalize-Facebook-For-Conversation Unit Tests', () => {
     try {
       func(textMsgParams);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorNoFacebookData);
     }
   });

--- a/test/unit/starter-code/normalize-for-conversation/test.starter-code.normalize-slack-for-conversation.js
+++ b/test/unit/starter-code/normalize-for-conversation/test.starter-code.normalize-slack-for-conversation.js
@@ -218,7 +218,6 @@ describe('Starter Code Normalize-Slack-For-Conversation Unit Tests', () => {
     try {
       func(textMessageParams);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorBadSupplier);
     }
   });
@@ -229,7 +228,6 @@ describe('Starter Code Normalize-Slack-For-Conversation Unit Tests', () => {
     try {
       func(textMessageParams);
     } catch (e) {
-      assert.equal('AssertionError', e.name);
       assert.equal(e.message, errorNoSlackData);
     }
   });


### PR DESCRIPTION
Added support for a "pause" response from Conversation which looks like the following:
```
{
"response_type": "pause",
"time": "1000",
"typing": true
}
```

Facebook normalizer handles it by adding a sender_action payload as follows:
```js
{
"sender_action": "typing_on",
"time": "1000"
}
``` 
Slack Events API currently does not have support for typing events so the normalizer will simply sleep for the specified time duration before sending the subsequent response(s).