### PR TITLE
Unfurling audio and video responses from Watson Conversation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ pids
 # Production system credentials file
 providers.json
 
+# Test environment file
+test/resources/.env
+
 # Ignore changes in slack and OW binding files so devs can use their own slack apps and namespaces
 test/resources/openwhisk-bindings.json
 test/resources/slack-bindings.json

--- a/starter-code/normalize-for-channel/normalize-conversation-for-slack.js
+++ b/starter-code/normalize-for-channel/normalize-conversation-for-slack.js
@@ -111,6 +111,12 @@ function insertConversationOutput(params, output) {
         case 'image':
           slackOutput.message.push(generateSlackImageData(element));
           break;
+        case 'audio':
+          slackOutput.message.push(generateSlackAudioData(element));
+          break;
+        case 'video':
+          slackOutput.message.push(generateSlackVideoData(element));
+          break;
         case 'option':
           slackOutput.message.push(generateSlackOptionsData(element));
           break;
@@ -175,6 +181,34 @@ function generateSlackImageData(element) {
         image_url: element.source
       }
     ]
+  };
+}
+
+/**
+ * Converts the generic formatted audio to a Slack audio link to unfurl.
+ *
+ * @param  {JSON} element - generic formatted audio element
+ * @return {JSON}         - element containing audio link to unfurl
+ */
+function generateSlackAudioData(element) {
+  return {
+    text: `<${element.source}|${element.title}>`,
+    unfurl_links: true,
+    unfurl_media: true
+  };
+}
+
+/**
+ * Converts the generic formatted video to a Slack video link to unfurl.
+ *
+ * @param  {JSON} element - generic formatted video element
+ * @return {JSON}         - element containing video link to unfurl
+ */
+function generateSlackVideoData(element) {
+  return {
+    text: `<${element.source}|${element.title}>`,
+    unfurl_links: true,
+    unfurl_media: true
   };
 }
 

--- a/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-slack.js
+++ b/test/unit/starter-code/normalize-for-channel/test.starter-code.normalize-conversation-for-slack.js
@@ -328,6 +328,78 @@ describe('Starter-Code Normalize-For-Slack Unit Tests', () => {
     );
   });
 
+  it('validate normalization works for generic response_type - audio', () => {
+    delete params.conversation.output.text;
+    delete expectedResult.raw_output_data.conversation.output.text;
+    delete expectedResult.text;
+
+    // Add a generic image response from Conversation
+    params.conversation.output.generic = [
+      {
+        response_type: 'audio',
+        title: 'Some audio here',
+        description: 'some audio here',
+        source: 'https://this.is.an/audio.mp3'
+      }
+    ];
+
+    expectedResult.raw_output_data.conversation.output.generic = params.conversation.output.generic;
+    expectedResult = Object.assign(expectedResult, {
+      message: [
+        {
+          text: '<https://this.is.an/audio.mp3|Some audio here>',
+          unfurl_links: true,
+          unfurl_media: true
+        }
+      ]
+    });
+
+    return actionNormForSlack(params).then(
+      result => {
+        assert.deepEqual(result, expectedResult);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
+  it('validate normalization works for generic response_type - video', () => {
+    delete params.conversation.output.text;
+    delete expectedResult.raw_output_data.conversation.output.text;
+    delete expectedResult.text;
+
+    // Add a generic image response from Conversation
+    params.conversation.output.generic = [
+      {
+        response_type: 'video',
+        title: 'Some video here',
+        description: 'some video here',
+        source: 'https://this.is.a/video.mp4'
+      }
+    ];
+
+    expectedResult.raw_output_data.conversation.output.generic = params.conversation.output.generic;
+    expectedResult = Object.assign(expectedResult, {
+      message: [
+        {
+          text: '<https://this.is.a/video.mp4|Some video here>',
+          unfurl_links: true,
+          unfurl_media: true
+        }
+      ]
+    });
+
+    return actionNormForSlack(params).then(
+      result => {
+        assert.deepEqual(result, expectedResult);
+      },
+      error => {
+        assert(false, error);
+      }
+    );
+  });
+
   it('validate normalization works for generic response_type - option', () => {
     delete params.conversation.output.text;
     delete expectedResult.raw_output_data.conversation.output.text;


### PR DESCRIPTION
- Audio and video responses coming from Watson Conversation will now be sent to Slack in a format that Slack servers can attempt to unfurl.

- Slight update to git ignore to ignore private environment files.